### PR TITLE
feat: Add integration-like unit tests for RL agents

### DIFF
--- a/jcog/rl/src/test/java/jcog/tensor/rl/RLAgentTestBase.java
+++ b/jcog/rl/src/test/java/jcog/tensor/rl/RLAgentTestBase.java
@@ -1,0 +1,244 @@
+package jcog.tensor.rl;
+
+import jcog.tensor.rl.env.SyntheticEnvironment;
+import jcog.tensor.rl.pg.AbstrPG;
+import jcog.tensor.rl.pg.PGBuilder;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public abstract class RLAgentTestBase {
+
+    protected static final int DEFAULT_INPUTS_CONTINUOUS = 2;
+    protected static final int DEFAULT_OUTPUTS_CONTINUOUS = 2;
+    protected static final int DEFAULT_INPUTS_GRID = 2; // x, y
+    protected static final int DEFAULT_OUTPUTS_GRID = 4; // up, down, left, right
+
+    protected static final double LEARNING_THRESHOLD_IMPROVEMENT = 0.1; // Min improvement factor
+    protected static final double MIN_PERFORMANCE_MATCHING_TASK = -0.1; // For the matching task specifically
+
+    protected Random random = new Random(12345); // For environment and reproducible tests
+
+    /**
+     * Trains an agent on a given synthetic environment.
+     *
+     * @param agent The agent to train.
+     * @param env The environment to train on.
+     * @param totalEpisodes The total number of episodes to train for.
+     * @param maxStepsPerEpisode The maximum steps per episode.
+     * @return A list of total rewards per episode.
+     */
+    protected List<Double> trainAgent(AbstrPG agent, SyntheticEnvironment env, int totalEpisodes, int maxStepsPerEpisode) {
+        List<Double> episodeRewards = new ArrayList<>(totalEpisodes);
+
+        for (int episode = 0; episode < totalEpisodes; episode++) {
+            double[] currentState = env.reset();
+            double currentEpisodeReward = 0;
+            double lastRewardSignal = 0; // Initial reward signal for the first step
+            boolean doneSignal = false;    // Initial done signal
+
+            for (int step = 0; step < maxStepsPerEpisode; step++) {
+                double[] action;
+                if (env.isDiscreteActionSpace()) {
+                    // For discrete actions, agent.act() might expect to produce discrete actions directly
+                    // or produce probabilities. PGBuilder agents typically produce continuous actions
+                    // that might need to be discretized (e.g., by argmax for policy).
+                    // For now, assume agent.act can handle it or adapt PGBuilder output.
+                    // This part might need refinement based on specific agent capabilities.
+                    // The current PG agents output continuous values; for discrete, we'd typically argmax.
+                    // However, `act` itself takes state, reward, done. The policy inside will decide action.
+                    // Let's assume the agent's internal policy handles the output type correctly.
+                    // If it's a discrete env, the agent should be configured for discrete output.
+                    // PGBuilder currently focuses on continuous outputs.
+                    // This is a simplification for now.
+                    action = agent.act(currentState, lastRewardSignal, doneSignal);
+                } else {
+                    action = agent.act(currentState, lastRewardSignal, doneSignal);
+                }
+
+                SyntheticEnvironment.StepResult result;
+                if (env.isDiscreteActionSpace()) {
+                    // We need to convert the action (typically continuous for PG) to discrete.
+                    // A common way is to take the argmax if the output represents probabilities,
+                    // or if it's a single value, discretize it.
+                    // This is a known challenge when applying continuous-output agents to discrete envs.
+                    // For now, let's assume the environment or a wrapper handles this.
+                    // Or, the agent is specifically a discrete-action variant.
+                    // For this test base, we'll assume the `action` from `agent.act` must be converted.
+                    // This is a placeholder for a more robust solution.
+                    int discreteAction = selectDiscreteAction(action, env.actionDimension());
+                    result = env.step(discreteAction);
+                } else {
+                    result = env.step(action);
+                }
+
+                lastRewardSignal = result.reward;
+                doneSignal = result.done;
+                currentState = result.nextState;
+                currentEpisodeReward += result.reward;
+
+                if (doneSignal) {
+                    // Final update for the episode if agent expects it (e.g. REINFORCE)
+                    // Some agents might do this internally based on the done signal.
+                    // For PPO, VPG, etc., the `act` call with done=true triggers episode processing.
+                    agent.act(currentState, lastRewardSignal, true); // Signal episode end
+                    break;
+                }
+            }
+            episodeRewards.add(currentEpisodeReward);
+        }
+        return episodeRewards;
+    }
+
+    /**
+     * Selects a discrete action from a continuous action vector (e.g., policy output).
+     * This is a simple argmax implementation.
+     */
+    protected int selectDiscreteAction(double[] continuousAction, int numDiscreteActions) {
+        if (continuousAction.length != numDiscreteActions && continuousAction.length == 1 && numDiscreteActions > 1) {
+            // If agent outputs a single value for a multi-action discrete space,
+            // this is likely an error in setup or agent type.
+            // However, for robustness, we can try to map it.
+            // This is a very naive way, assuming the single value is meaningful for discretization.
+            // E.g. if action is in [-1, 1], scale it to [0, numDiscreteActions-1]
+            double scaledAction = (continuousAction[0] + 1.0) / 2.0 * (numDiscreteActions - 1);
+            return Math.min(numDiscreteActions - 1, Math.max(0, (int) Math.round(scaledAction)));
+        } else if (continuousAction.length != numDiscreteActions) {
+             throw new IllegalArgumentException(
+                "Continuous action dimension (" + continuousAction.length +
+                ") must match number of discrete actions (" + numDiscreteActions +
+                ") for argmax selection, or be 1 for simple scaling."
+             );
+        }
+
+        int maxIndex = 0;
+        for (int i = 1; i < continuousAction.length; i++) {
+            if (continuousAction[i] > continuousAction[maxIndex]) {
+                maxIndex = i;
+            }
+        }
+        return maxIndex;
+    }
+
+
+    /**
+     * Evaluates an agent's performance on an environment without training.
+     *
+     * @param agent The agent to evaluate.
+     * @param env The environment for evaluation.
+     * @param numEpisodes Number of episodes to run for evaluation.
+     * @param maxStepsPerEpisode Max steps in each evaluation episode.
+     * @return Average reward over the evaluation episodes.
+     */
+    protected double evaluateAgent(AbstrPG agent, SyntheticEnvironment env, int numEpisodes, int maxStepsPerEpisode) {
+        double totalReward = 0;
+        Random evalRandom = new Random(random.nextLong()); // Use a different seed for evaluation consistency if needed
+
+        for (int i = 0; i < numEpisodes; i++) {
+            double[] currentState = env.reset(); // Ensure env uses its own randomness or is seeded
+            double episodeReward = 0;
+            // For evaluation, typically don't pass reward/done from previous step,
+            // but act() API for these agents expects it.
+            // We can pass 0 and false, as training aspect is not used.
+            double lastEvalReward = 0.0;
+            boolean lastEvalDone = false;
+
+            for (int step = 0; step < maxStepsPerEpisode; step++) {
+                // In evaluation, use the deterministic action if possible, or mean of distribution.
+                // The _action method in AbstrPG is suitable for this as it typically samples.
+                // For a more deterministic evaluation, one might need access to a deterministic policy.
+                // PGBuilder's AbstrPG._action(Tensor state, boolean training) is ideal.
+                // However, we only have the AbstrPG interface here.
+                // A simple way: call `act` but ensure it doesn't trigger learning.
+                // Most PGBuilder agents' `act` method also does `remember` and `update`.
+                // This is not ideal for pure evaluation.
+                // The `_action(Tensor state)` is protected.
+                //
+                // Workaround: PGBuilderTest uses `model._action(Tensor.row(state), true)`
+                // We need a similar capability. For now, we'll use `act` and accept that it might
+                // call remember/update, which is not pure evaluation but a practical compromise.
+                // Or, we can use `agent.policy.apply(Tensor.row(currentState))` if policy is public
+                // and then sample/argmax.
+                // PGBuilder's `_action(state, training)` is what we need.
+                // For now, let's assume `act` is used, and for evaluation, its learning side effects are minimal
+                // or the agent is in an eval mode (not explicitly supported by AbstrPG).
+
+                double[] actionVec = agent.act(currentState, lastEvalReward, lastEvalDone);
+
+                SyntheticEnvironment.StepResult result;
+                 if (env.isDiscreteActionSpace()) {
+                    int discreteAction = selectDiscreteAction(actionVec, env.actionDimension());
+                    result = env.step(discreteAction);
+                } else {
+                    result = env.step(actionVec);
+                }
+
+                currentState = result.nextState;
+                episodeReward += result.reward;
+                lastEvalReward = result.reward; // Store for next call to act
+                lastEvalDone = result.done;     // Store for next call to act
+
+                if (result.done) {
+                    // If agent needs a final signal for "done" even in eval, send it.
+                    agent.act(currentState, lastEvalReward, true);
+                    break;
+                }
+            }
+            totalReward += episodeReward;
+        }
+        return totalReward / numEpisodes;
+    }
+
+    protected void assertLearningOccurs(List<Double> rewardsHistory, int window, String agentName) {
+        Assertions.assertTrue(rewardsHistory.size() > window * 2,
+                agentName + ": Not enough reward history to evaluate learning. Collected: " + rewardsHistory.size());
+
+        double initialPerf = rewardsHistory.subList(0, window).stream().mapToDouble(Double::doubleValue).average().orElse(-Double.MAX_VALUE);
+        double finalPerf = rewardsHistory.subList(rewardsHistory.size() - window, rewardsHistory.size()).stream().mapToDouble(Double::doubleValue).average().orElse(-Double.MAX_VALUE);
+
+        String learningCurve = rewardsHistory.stream().map(r -> String.format("%.4f", r)).collect(Collectors.joining(", "));
+        System.out.printf("Performance for %s (avg over %d episodes): Initial: %.4f, Final: %.4f. Curve: [%s]%n",
+                agentName, window, initialPerf, finalPerf, learningCurve);
+
+        Assertions.assertTrue(finalPerf > initialPerf + Math.abs(initialPerf * LEARNING_THRESHOLD_IMPROVEMENT) + 1e-6, // Add epsilon for floating point
+                agentName + ": Final performance (" + finalPerf + ") should be significantly better than initial (" + initialPerf + ")." +
+                " Learning curve: " + learningCurve);
+    }
+
+    /**
+     * Helper to create a PGBuilder instance with common defaults for testing.
+     * Specific tests can then customize it.
+     */
+    protected PGBuilder createDefaultPGBuilder(PGBuilder.Algorithm algo, int inputs, int outputs, boolean isDiscrete) {
+        var builder = new PGBuilder(inputs, outputs).algorithm(algo);
+        builder.policy(p -> p.hiddenLayers(32, 32).optimizer(o -> o.learningRate(1e-3f)));
+
+        if (isDiscrete) {
+            // For discrete actions, PGBuilder needs to be configured appropriately if it supports it.
+            // This might involve setting action distribution to categorical, or ensuring output layer
+            // matches number of actions for softmax. PGBuilder primarily targets continuous.
+            // This is a placeholder for future PGBuilder enhancements for discrete actions.
+            // For now, we assume the output layer of policy is `outputs` (num_actions) and we apply argmax.
+        }
+
+
+        switch (algo) {
+            case PPO, VPG, REINFORCE ->
+                    builder.value(v -> v.hiddenLayers(32, 32).optimizer(o -> o.learningRate(1e-3f)));
+            case SAC -> builder.qNetworks(q -> q.hiddenLayers(32, 32).optimizer(o -> o.learningRate(1e-3f)));
+            case DDPG -> builder.value(v -> v.hiddenLayers(32, 32).optimizer(o -> o.learningRate(1e-3f)))
+                    .action(a -> a.distribution(PGBuilder.ActionConfig.Distribution.DETERMINISTIC));
+        }
+        builder.hyperparams(h -> h.epochs(1).policyUpdateFreq(1).gamma(0.99f)); // Sensible defaults for tests
+        builder.memory(m -> m
+                .episodeLength(isDiscrete ? 64 : 32) // Grid world might take more steps
+                .replayBuffer(rb -> rb.capacity(isDiscrete ? 2048 : 10000).batchSize(isDiscrete ? 64 : 128))
+        );
+        return builder;
+    }
+}

--- a/jcog/rl/src/test/java/jcog/tensor/rl/env/SimpleGridWorld.java
+++ b/jcog/rl/src/test/java/jcog/tensor/rl/env/SimpleGridWorld.java
@@ -1,0 +1,130 @@
+package jcog.tensor.rl.env;
+
+import java.util.Arrays;
+import java.util.Random;
+
+public class SimpleGridWorld implements SyntheticEnvironment {
+
+    private final int width;
+    private final int height;
+    private final int[] startState;
+    private final int[] goalState;
+    private final double goalReward;
+    private final double wallPenalty;
+    private final double stepPenalty;
+    private final int maxSteps;
+
+    private int[] currentState;
+    private int currentStep;
+    private final Random random;
+
+    public static final int ACTION_UP = 0;
+    public static final int ACTION_DOWN = 1;
+    public static final int ACTION_LEFT = 2;
+    public static final int ACTION_RIGHT = 3;
+
+    public SimpleGridWorld(int width, int height, int[] startState, int[] goalState,
+                           double goalReward, double wallPenalty, double stepPenalty, int maxSteps) {
+        this.width = width;
+        this.height = height;
+        this.startState = Arrays.copyOf(startState, startState.length);
+        this.goalState = Arrays.copyOf(goalState, goalState.length);
+        this.goalReward = goalReward;
+        this.wallPenalty = wallPenalty;
+        this.stepPenalty = stepPenalty;
+        this.maxSteps = maxSteps;
+        this.random = new Random(); // Or allow seeding
+        reset();
+    }
+
+    public SimpleGridWorld() {
+        this(5, 5, new int[]{0, 0}, new int[]{4, 4}, 1.0, -0.5, -0.01, 100);
+    }
+
+    @Override
+    public int stateDimension() {
+        return 2; // x, y coordinates
+    }
+
+    @Override
+    public int actionDimension() {
+        return 4; // Up, Down, Left, Right
+    }
+
+    @Override
+    public boolean isDiscreteActionSpace() {
+        return true;
+    }
+
+    @Override
+    public double[] reset() {
+        this.currentState = Arrays.copyOf(startState, startState.length);
+        this.currentStep = 0;
+        return Arrays.stream(this.currentState).asDoubleStream().toArray();
+    }
+
+    @Override
+    public StepResult step(double[] action) {
+        throw new UnsupportedOperationException("SimpleGridWorld uses discrete actions. Call step(int action).");
+    }
+
+    @Override
+    public StepResult step(int action) {
+        if (action < 0 || action >= actionDimension()) {
+            throw new IllegalArgumentException("Invalid action: " + action);
+        }
+
+        currentStep++;
+        double reward = stepPenalty;
+        boolean done = false;
+
+        int[] nextStateRaw = Arrays.copyOf(currentState, currentState.length);
+
+        switch (action) {
+            case ACTION_UP:    nextStateRaw[1]--; break;
+            case ACTION_DOWN:  nextStateRaw[1]++; break;
+            case ACTION_LEFT:  nextStateRaw[0]--; break;
+            case ACTION_RIGHT: nextStateRaw[0]++; break;
+        }
+
+        // Check bounds
+        if (nextStateRaw[0] < 0 || nextStateRaw[0] >= width ||
+            nextStateRaw[1] < 0 || nextStateRaw[1] >= height) {
+            reward += wallPenalty;
+            // Agent stays in the same place if it hits a wall
+        } else {
+            currentState = nextStateRaw;
+        }
+
+        // Check if goal reached
+        if (Arrays.equals(currentState, goalState)) {
+            reward += goalReward;
+            done = true;
+        }
+
+        // Check max steps
+        if (currentStep >= maxSteps) {
+            done = true;
+        }
+
+        return new StepResult(Arrays.stream(currentState).asDoubleStream().toArray(), reward, done);
+    }
+
+    // Optional: A method to render or print the grid (useful for debugging)
+    public String render() {
+        StringBuilder sb = new StringBuilder();
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                if (x == currentState[0] && y == currentState[1]) {
+                    sb.append("A "); // Agent
+                } else if (x == goalState[0] && y == goalState[1]) {
+                    sb.append("G "); // Goal
+                } else {
+                    sb.append(". "); // Empty
+                }
+            }
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+}

--- a/jcog/rl/src/test/java/jcog/tensor/rl/env/SyntheticEnvironment.java
+++ b/jcog/rl/src/test/java/jcog/tensor/rl/env/SyntheticEnvironment.java
@@ -1,0 +1,32 @@
+package jcog.tensor.rl.env;
+
+import java.util.Map;
+
+public interface SyntheticEnvironment {
+    int stateDimension();
+    int actionDimension(); // For continuous actions, this is the dimension; for discrete, it's the count.
+    boolean isDiscreteActionSpace();
+
+    double[] reset(); // Returns initial state
+
+    StepResult step(double[] action); // For continuous actions
+    StepResult step(int action);    // For discrete actions
+
+    class StepResult {
+        public final double[] nextState;
+        public final double reward;
+        public final boolean done;
+        public final Map<String, Object> info;
+
+        public StepResult(double[] nextState, double reward, boolean done, Map<String, Object> info) {
+            this.nextState = nextState;
+            this.reward = reward;
+            this.done = done;
+            this.info = info;
+        }
+
+        public StepResult(double[] nextState, double reward, boolean done) {
+            this(nextState, reward, done, null);
+        }
+    }
+}

--- a/jcog/rl/src/test/java/jcog/tensor/rl/pg/PolicyGradientAgentTests.java
+++ b/jcog/rl/src/test/java/jcog/tensor/rl/pg/PolicyGradientAgentTests.java
@@ -1,0 +1,152 @@
+package jcog.tensor.rl.pg;
+
+import jcog.tensor.rl.RLAgentTestBase;
+import jcog.tensor.rl.env.SimpleGridWorld;
+import jcog.tensor.rl.env.SyntheticEnvironment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("RLAlgorithmTests")
+@DisplayName("Policy Gradient Agent Tests")
+public class PolicyGradientAgentTests extends RLAgentTestBase {
+
+    // Helper to create agents using PGBuilder
+    private AbstrPG createAgent(PGBuilder.Algorithm algo, int inputs, int outputs, boolean isDiscrete) {
+        PGBuilder builder = createDefaultPGBuilder(algo, inputs, outputs, isDiscrete);
+
+        // Specific configurations if needed, e.g., for discrete action spaces
+        if (isDiscrete) {
+            // PGBuilder's default action distribution is Gaussian, which is for continuous.
+            // For discrete environments, the policy network's output (size `outputs`)
+            // is typically fed into a softmax and then sampled (Categorical distribution).
+            // RLAgentTestBase.selectDiscreteAction uses argmax on the raw output,
+            // which is a common simplification if the network learns appropriate logits.
+            // Ideally, PGBuilder would allow specifying a Categorical distribution.
+            // builder.action(a -> a.distribution(PGBuilder.ActionConfig.Distribution.CATEGORICAL));
+        }
+
+        // Some algorithms might need longer episode lengths or different hyperparams by default
+        if (algo == PGBuilder.Algorithm.REINFORCE && isDiscrete) {
+            builder.memory(m -> m.episodeLength(128)); // REINFORCE might need more samples per update
+        }
+        if (algo == PGBuilder.Algorithm.SAC || algo == PGBuilder.Algorithm.DDPG) {
+             builder.hyperparams(h -> h.gamma(0.95f)); // Common for off-policy
+        }
+
+
+        return builder.build();
+    }
+
+    @ParameterizedTest(name = "{0} on SimpleGridWorld")
+    @EnumSource(value = PGBuilder.Algorithm.class,
+                 names = {"REINFORCE", "VPG", "PPO"}) // SAC and DDPG are typically for continuous.
+    @DisplayName("Discrete Action Test: SimpleGridWorld")
+    @Timeout(value = 5, unit = TimeUnit.MINUTES) // Generous timeout for potentially slow learning
+    void testAgentOnSimpleGridWorld(PGBuilder.Algorithm algo) {
+        SimpleGridWorld env = new SimpleGridWorld(); // Default 5x5 grid
+        AbstrPG agent = createAgent(algo, env.stateDimension(), env.actionDimension(), true);
+
+        int totalEpisodes = 300;
+        int maxStepsPerEpisode = env.maxSteps; // Use env's max steps
+        int evaluationWindow = 30;
+
+        if (algo == PGBuilder.Algorithm.REINFORCE) {
+            totalEpisodes = 700; // REINFORCE is less sample efficient
+            evaluationWindow = 70;
+        }
+
+        List<Double> rewardsHistory = trainAgent(agent, env, totalEpisodes, maxStepsPerEpisode);
+        assertLearningOccurs(rewardsHistory, evaluationWindow, algo + " on SimpleGridWorld");
+
+        double avgEvalReward = evaluateAgent(agent, env, 20, maxStepsPerEpisode);
+        System.out.printf("%s SimpleGridWorld - Avg Eval Reward after training: %.4f%n", algo, avgEvalReward);
+
+        // Performance expectation can vary. PPO/VPG should do better than REINFORCE.
+        double expectedMinReward = -(maxStepsPerEpisode * env.stepPenalty) * 0.5; // Should at least do better than random walk
+        if (algo == PGBuilder.Algorithm.PPO || algo == PGBuilder.Algorithm.VPG) {
+            expectedMinReward = 0; // Expect PPO/VPG to solve it (positive reward)
+        }
+
+        assertTrue(avgEvalReward > expectedMinReward,
+                algo + " should achieve a reasonable score on SimpleGridWorld. Got: " + avgEvalReward + ", Expected > " + expectedMinReward);
+    }
+
+
+    // MatchingEnv for continuous tests
+    private static class MatchingEnv implements SyntheticEnvironment {
+        private final int dim;
+        private final Random randomInstance; // Use instance for better control if needed, or base class random
+        private double[] currentState;
+
+        public MatchingEnv(int dim, Random randomSeedGenerator) {
+            this.dim = dim;
+            this.randomInstance = new Random(randomSeedGenerator.nextLong()); // Seed per instance
+        }
+
+        @Override public int stateDimension() { return dim; }
+        @Override public int actionDimension() { return dim; }
+        @Override public boolean isDiscreteActionSpace() { return false; }
+
+        @Override public double[] reset() {
+            currentState = randomInstance.doubles(dim, -1.0, 1.0).toArray();
+            return currentState;
+        }
+
+        @Override public StepResult step(double[] action) {
+            double mse = 0;
+            for (int i = 0; i < dim; i++) {
+                mse += Math.pow(currentState[i] - action[i], 2);
+            }
+            double reward = -mse / dim;
+            // For matching task, each step is an independent trial, so "done" is true.
+            // The next state is a new random state.
+            double[] nextState = randomInstance.doubles(dim, -1.0, 1.0).toArray();
+            // currentState = nextState; // Not needed as it's reset effectively
+            return new StepResult(nextState, reward, true);
+        }
+        @Override public StepResult step(int action) { throw new UnsupportedOperationException("MatchingEnv uses continuous actions."); }
+    }
+
+    @ParameterizedTest(name = "{0} on Matching Task")
+    @EnumSource(PGBuilder.Algorithm.class) // Test all algorithms that support continuous actions
+    @DisplayName("Continuous Action Test: Matching Task")
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
+    void testAgentOnMatchingTask(PGBuilder.Algorithm algo) {
+        // DDPG and SAC are primarily for continuous action spaces.
+        // REINFORCE, VPG, PPO can also handle continuous actions with appropriate policy distributions (e.g., Gaussian).
+        MatchingEnv env = new MatchingEnv(DEFAULT_INPUTS_CONTINUOUS, this.random); // Use base class random for seeding
+        AbstrPG agent = createAgent(algo, env.stateDimension(), env.actionDimension(), false);
+
+        // Matching task uses 1-step episodes. totalEpisodes effectively means total training steps.
+        int totalTrainingSteps = (algo == PGBuilder.Algorithm.REINFORCE) ? 12000 : 8000;
+        if (algo == PGBuilder.Algorithm.SAC || algo == PGBuilder.Algorithm.DDPG) {
+            totalTrainingSteps = 10000; // Off-policy might need a bit more interaction for this setup
+        }
+
+        int maxStepsPerEpisode = 1; // Env is always done in 1 step
+        int evaluationWindow = totalTrainingSteps / 10; // Evaluate over last 10% of steps
+
+        List<Double> rewardsHistory = trainAgent(agent, env, totalTrainingSteps, maxStepsPerEpisode);
+        assertLearningOccurs(rewardsHistory, evaluationWindow, algo + " on MatchingTask");
+
+        double avgEvalReward = evaluateAgent(agent, env, 200, maxStepsPerEpisode);
+        System.out.printf("%s MatchingTask - Avg Eval Reward after training: %.4f%n", algo, avgEvalReward);
+
+        double expectedMinPerf = MIN_PERFORMANCE_MATCHING_TASK;
+        if (algo == PGBuilder.Algorithm.SAC || algo == PGBuilder.Algorithm.DDPG) {
+            expectedMinPerf = -0.05; // Expect better performance from SAC/DDPG
+        }
+
+        assertTrue(avgEvalReward > expectedMinPerf,
+             algo + " should achieve a good score on MatchingTask. Got: " + avgEvalReward + ", Expected > " + expectedMinPerf);
+    }
+}


### PR DESCRIPTION
Adds a test suite for policy gradient agents (REINFORCE, PPO, VPG, SAC, DDPG). Includes:
- SyntheticEnvironment interface and SimpleGridWorld implementation.
- RLAgentTestBase for common test utilities.
- PolicyGradientAgentTests using parameterized tests for different algorithms on discrete and continuous synthetic tasks.

Note: Unable to verify tests due to persistent Maven build issues preventing successful compilation and test execution of the 'jcog/rl' module.