### PR TITLE
Refactor PGBuilder to constructor-based DI and public final fields

### DIFF
--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg/AbstrPG.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg/AbstrPG.java
@@ -14,15 +14,22 @@ import org.jetbrains.annotations.Nullable;
 import java.util.function.Consumer;
 
 public abstract class AbstrPG {
-    protected final int inputs, outputs;
-    protected final RandomBits rng = new RandomBits(new XoRoShiRo128PlusRandom());
-    public Consumer<double[]> actionFilter = a -> {
-    };
+    public final int inputs; // Changed to public final
+    public final int outputs; // Changed to public final
+    protected final RandomBits rng = new RandomBits(new XoRoShiRo128PlusRandom()); // Keep protected final for internal use
+    public final Consumer<double[]> actionFilter; // Changed to public final
 
-    protected AbstrPG(int inputs, int outputs) {
+    protected AbstrPG(int inputs, int outputs, Consumer<double[]> actionFilter) {
         this.inputs = inputs;
         this.outputs = outputs;
+        this.actionFilter = Objects.requireNonNull(actionFilter, "actionFilter cannot be null");
     }
+
+    // Overloaded constructor for default actionFilter
+    protected AbstrPG(int inputs, int outputs) {
+        this(inputs, outputs, a -> {}); // Default no-op action filter
+    }
+
 
     public abstract double[] act(double[] input, double reward, boolean done);
 

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg/PPO.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg/PPO.java
@@ -6,6 +6,15 @@ import jcog.tensor.Tensor;
 
 import java.util.List;
 
+/**
+ * @deprecated This class represents an older PPO implementation.
+ *             Please use {@link PGBuilder.PPOStrategy} (found within PGBuilder.java)
+ *             by directly instantiating it with {@link PGBuilder.GaussianPolicy},
+ *             {@link PGBuilder.ValueNetwork}, and other necessary components
+ *             through constructor injection. The new PPOStrategy offers a more
+ *             standard and flexible PPO implementation, including GAE.
+ */
+@Deprecated
 public class PPO extends VPG {
 
     public final Clipping clipping =

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg/Reinforce.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg/Reinforce.java
@@ -6,6 +6,13 @@ import jcog.tensor.Tensor;
 
 import java.util.function.UnaryOperator;
 
+/**
+ * @deprecated This class represents an older REINFORCE implementation and served as a base for VPG.java.
+ *             Please use {@link PGBuilder.ReinforceStrategy} (found within PGBuilder.java)
+ *             for a standard REINFORCE algorithm, instantiated with {@link PGBuilder.GaussianPolicy}
+ *             and other components via constructor injection. This old version has a non-standard policy network structure.
+ */
+@Deprecated
 public class Reinforce extends AbstractReinforce {
 
     final UnaryOperator<Tensor> policyActivation =

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg/VPG.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg/VPG.java
@@ -12,7 +12,16 @@ import static jcog.tensor.Models.Layers.layerLerp;
 
 /**
  * Vanilla Policy Gradient
+ * @deprecated This class represents an older VPG (Vanilla Policy Gradient / REINFORCE with a baseline) implementation.
+ *             For REINFORCE without a baseline, please use {@link PGBuilder.ReinforceStrategy}.
+ *             For VPG (REINFORCE with a baseline) or more advanced Actor-Critic methods like A2C/A3C,
+ *             it's recommended to use {@link PGBuilder.PPOStrategy} and configure its hyperparameters
+ *             (e.g., gamma, lambda for GAE which can approximate VPG advantages, ppoClip can be made very large)
+ *             or await/implement a dedicated ActorCriticStrategy using the new framework components
+ *             ({@link PGBuilder.GaussianPolicy}, {@link PGBuilder.ValueNetwork}).
+ *             The policy network in this old VPG has a non-standard structure.
  */
+@Deprecated
 public class VPG extends Reinforce {
 
     public final UnaryOperator<Tensor> value;

--- a/jcog/rl/src/main/java/jcog/tensor/rl/util/RLNetworkUtils.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/util/RLNetworkUtils.java
@@ -1,0 +1,56 @@
+package jcog.tensor.rl.util;
+
+import jcog.tensor.Models;
+import jcog.tensor.Models.Linear;
+import jcog.tensor.Tensor;
+import jcog.tensor.rl.pg.PGBuilder.NetworkConfig; // PGBuilder.NetworkConfig will be just NetworkConfig after imports cleanup
+
+import java.util.Arrays;
+import java.util.function.UnaryOperator;
+import java.util.stream.IntStream;
+
+public final class RLNetworkUtils {
+
+    private RLNetworkUtils() {
+        // Utility class, not to be instantiated
+    }
+
+    /**
+     * Creates a Multi-Layer Perceptron (MLP) with specific initialization and dropout settings
+     * commonly used in RL.
+     *
+     * @param ins    Number of input units.
+     * @param outs   Number of output units.
+     * @param config Network configuration (hidden layers, activations, init, dropout).
+     * @return A UnaryOperator representing the MLP.
+     */
+    public static UnaryOperator<Tensor> createMlp(int ins, int outs, NetworkConfig config) {
+        Objects.requireNonNull(config, "NetworkConfig cannot be null for MLP creation");
+        var layers = IntStream.concat(IntStream.of(ins), Arrays.stream(config.hiddenLayers())).toArray();
+        layers = IntStream.concat(Arrays.stream(layers), IntStream.of(outs)).toArray();
+
+        return new Models.Layers(config.activation(), config.outputActivation(), config.biasInLastLayer(), layers) {
+            @Override
+            protected Linear layer(int l, int maxLayers, int I, int O, UnaryOperator<Tensor> a, boolean bias) {
+                var linearLayer = (Linear) super.layer(l, maxLayers, I, O, a, bias);
+                if (config.orthogonalInit()) {
+                    Tensor.orthoInit(linearLayer.weight, (l < maxLayers - 1) ? Math.sqrt(2.0) : 0.01);
+                    if (bias && linearLayer.bias != null) linearLayer.bias.zero();
+                }
+                return linearLayer;
+            }
+
+            @Override
+            protected void afterLayer(int O, int l, int maxLayers) {
+                if (config.dropout() > 0 && l < maxLayers - 1) {
+                    // Accessing the 'layer' field of the anonymous Models.Layers subclass
+                    // This assumes 'layer' is accessible (e.g., protected or package-private in Models.Layers)
+                    // and refers to the list of layers being built.
+                    // If Models.Layers.layer is private, this pattern needs adjustment.
+                    // Assuming 'this.layer' refers to the list of layers in Models.Layers:
+                    super.layer.add(new Models.Dropout(config.dropout()));
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
- Replaced fluent PGBuilder API with direct constructor injection for all components (configurations, networks, strategies).
- All relevant configuration and component fields are now public final for transparency.
- Removed PGBuilder.Algorithm enum and AlgorithmConfigurator; strategies are now instantiated directly.
- ModelFactory methods were integrated into component constructors (e.g., OptimizerConfig.buildOptimizer) or moved to a new RLNetworkUtils class (for createMlp).
- Updated PolicyGradientModel and AbstrPG to use constructor DI for actionFilter and ensure public final fields.
- Deprecated old VPG, PPO, and Reinforce classes, guiding users to new strategies.
- Refactored PGBuilderTest.java and PolicyGradientAgentTests.java to use the new DI API.