### PR TITLE
Refactor Policy Gradient agents (REINFORCE, VPG, PPO)

### DIFF
--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/BasePolicyGradientAgent.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/BasePolicyGradientAgent.java
@@ -1,0 +1,93 @@
+package jcog.tensor.rl.agents.pg;
+
+// Removed unused imports for Tensor and Experience2 as they are not directly used in this abstract class's code.
+// Subclasses will import them as needed.
+
+/**
+ * An abstract base class for implementing {@link PolicyGradientAgent}.
+ * This class provides default implementations for managing the training mode status
+ * and the update count. Concrete agent implementations should extend this class
+ * and implement the core algorithmic logic.
+ *
+ * <p>Subclasses are responsible for initializing their specific networks, optimizers,
+ * memory buffers, and configurations. They must also override {@link #setTrainingMode(boolean)}
+ * to propagate the training mode to their internal neural network components.</p>
+ */
+public abstract class BasePolicyGradientAgent implements PolicyGradientAgent {
+
+    /**
+     * Flag indicating whether the agent is in training mode. Defaults to true.
+     * Subclasses should use and respect this flag in their {@code selectAction}
+     * and {@code recordExperience} methods.
+     */
+    protected boolean trainingMode = true;
+
+    /**
+     * Counter for the number of learning updates performed.
+     * Incremented by calling {@link #incrementUpdateCount()}.
+     */
+    protected long updateCount = 0;
+
+    /**
+     * Default constructor. Initializes {@code trainingMode} to true and {@code updateCount} to 0.
+     */
+    protected BasePolicyGradientAgent() {
+        // Default initialization is handled by field initializers.
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>This implementation returns the current value of the protected {@code trainingMode} field.</p>
+     */
+    @Override
+    public boolean isTrainingMode() {
+        return this.trainingMode;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>This implementation sets the protected {@code trainingMode} field.
+     * Subclasses <strong>must</strong> override this method to also propagate the training mode
+     * to their internal neural networks (e.g., policy and value function networks) by calling
+     * their respective {@code train(boolean)} methods.</p>
+     * <pre>{@code
+     * @Override
+     * public void setTrainingMode(boolean training) {
+     *     super.setTrainingMode(training); // Sets the flag in BasePolicyGradientAgent
+     *     this.policy.train(training);
+     *     if (this.valueFunction != null) {
+     *         this.valueFunction.train(training);
+     *     }
+     *     if (!training) { // Optional: clear memory when switching to evaluation
+     *         this.memory.clear();
+     *     }
+     * }
+     * }</pre>
+     */
+    @Override
+    public void setTrainingMode(boolean training) {
+        this.trainingMode = training;
+        // Subclasses MUST override to propagate to their networks.
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>This implementation returns the current value of the protected {@code updateCount} field.</p>
+     */
+    @Override
+    public long getUpdateCount() {
+        return this.updateCount;
+    }
+
+    /**
+     * Increments the learning update counter.
+     * Concrete agent implementations should call this method after successfully
+     * performing a learning update (e.g., at the end of their {@code update} method).
+     */
+    protected void incrementUpdateCount() {
+        this.updateCount++;
+    }
+
+    // Abstract methods from PolicyGradientAgent (selectAction, recordExperience, update,
+    // getPolicy, getValueFunction, getConfig, clearMemory) must be implemented by concrete subclasses.
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/PPOAgent.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/PPOAgent.java
@@ -1,0 +1,213 @@
+package jcog.tensor.rl.agents.pg;
+
+import jcog.tensor.Tensor;
+import jcog.tensor.rl.agents.pg.configs.PPOAgentConfig;
+import jcog.tensor.rl.agents.pg.memory.AgentMemory;
+import jcog.tensor.rl.agents.pg.memory.OnPolicyBuffer;
+import jcog.tensor.rl.agents.pg.networks.GaussianPolicyNet;
+import jcog.tensor.rl.agents.pg.networks.ValueNet;
+import jcog.tensor.rl.agents.pg.util.AgentUtils;
+import jcog.tensor.rl.pg.util.Experience2; // Contains oldLogProb
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class PPOAgent extends BasePolicyGradientAgent {
+
+    public final PPOAgentConfig config;
+    public final GaussianPolicyNet policy;
+    public final ValueNet valueFunction;
+    public final Tensor.Optimizer policyOptimizer;
+    public final Tensor.Optimizer valueOptimizer;
+    public final AgentMemory memory;
+
+    private final Tensor.GradQueue policyGradQueue;
+    private final Tensor.GradQueue valueGradQueue;
+
+    public PPOAgent(PPOAgentConfig config, int stateDim, int actionDim) {
+        Objects.requireNonNull(config, "Agent configuration cannot be null");
+        this.config = config;
+
+        this.policy = new GaussianPolicyNet(config.policyNetworkConfig(), stateDim, actionDim);
+        this.valueFunction = new ValueNet(config.valueNetworkConfig(), stateDim);
+
+        this.policyOptimizer = config.policyNetworkConfig().optimizer().build();
+        this.valueOptimizer = config.valueNetworkConfig().optimizer().build();
+
+        this.memory = new OnPolicyBuffer(config.memoryConfig().episodeLength().intValue());
+
+        this.policyGradQueue = new Tensor.GradQueue();
+        this.valueGradQueue = new Tensor.GradQueue();
+
+        setTrainingMode(true); // Initialize training mode by default
+    }
+
+    @Override
+    public double[] selectAction(Tensor state, boolean deterministic) {
+        // This method is required by the interface. For PPO, it's often better to also get the logProb.
+        // Callers can use selectActionWithLogProb if they need it for Experience2.
+        ActionWithLogProb result = selectActionWithLogProb(state, deterministic);
+        return result.action();
+    }
+
+    public record ActionWithLogProb(double[] action, Tensor logProb) {}
+
+    public ActionWithLogProb selectActionWithLogProb(Tensor state, boolean deterministic) {
+        try (var noGrad = Tensor.noGrad()) {
+            AgentUtils.GaussianDistribution dist = policy.getDistribution(
+                state,
+                config.actionConfig().sigmaMin().floatValue(),
+                config.actionConfig().sigmaMax().floatValue()
+            );
+            Tensor actionTensor = dist.sample(deterministic);
+            // Detach actionTensor before logProb if it's used in logProb calculation and has grad history.
+            // sample() from GaussianDistribution might or might not attach grad based on mu/sigma.
+            // dist.logProb internally handles this. Detaching logProb itself is good practice.
+            Tensor logProb = dist.logProb(actionTensor.detach());
+            return new ActionWithLogProb(actionTensor.clipUnitPolar().array(), logProb.detach());
+        }
+    }
+
+    @Override
+    public void recordExperience(Experience2 experience) {
+        Objects.requireNonNull(experience, "Experience object cannot be null.");
+        Objects.requireNonNull(experience.oldLogProb(), "Experience for PPO agent must include oldLogProb.");
+         if (!this.trainingMode) {
+            return; // Do not record or update if not in training mode
+        }
+        this.memory.add(experience);
+
+        boolean bufferFull = this.memory.size() >= config.memoryConfig().episodeLength().intValue();
+
+        if (bufferFull) {
+            update(0);
+            this.memory.clear();
+        }
+        // Optional: else if (experience.done() && this.memory.size() > 0) { update on early done }
+    }
+
+    @Override
+    public void update(long totalSteps) {
+        if (!this.trainingMode || this.memory.size() == 0) {
+            return;
+        }
+
+        List<Experience2> batch = this.memory.getAll();
+
+        Tensor states = Tensor.concatRows(batch.stream().map(Experience2::state).collect(Collectors.toList()));
+        Tensor actions = Tensor.concatRows(batch.stream().map(e -> Tensor.row(e.action())).collect(Collectors.toList()));
+        Tensor oldLogProbs = Tensor.concatRows(batch.stream().map(Experience2::oldLogProb).collect(Collectors.toList()));
+
+        Tensor advantages;
+        Tensor valueTargets;
+
+        try (var noGrad = Tensor.noGrad()) {
+            Tensor values = this.valueFunction.apply(states);
+
+            Tensor lastNextValue;
+            Experience2 lastExp = batch.get(batch.size() - 1);
+            if (!lastExp.done() && lastExp.nextState() != null) {
+                 lastNextValue = this.valueFunction.apply(lastExp.nextState());
+            } else {
+                lastNextValue = Tensor.zeros(1,1);
+            }
+
+            GAEResult gaeResult = computeGAE(batch, values, lastNextValue.scalar());
+            advantages = gaeResult.advantages();
+            valueTargets = gaeResult.valueTargets();
+        }
+
+        if (config.hyperparams().normalizeAdvantages()) {
+            double[] advantagesArray = advantages.array().clone();
+            AgentUtils.normalize(advantagesArray);
+            advantages = Tensor.row(advantagesArray).transpose();
+        }
+
+        for (int i = 0; i < config.hyperparams().epochs().intValue(); ++i) {
+            Tensor currentPredictedValues = this.valueFunction.apply(states); // Re-evaluate V(s) for current value net params
+            Tensor valueLoss = currentPredictedValues.loss(valueTargets.detach(), Tensor.Loss.MeanSquared);
+
+            valueGradQueue.clear();
+            valueLoss.minimize(valueGradQueue);
+            valueGradQueue.optimize(valueOptimizer);
+
+            AgentUtils.GaussianDistribution dist = policy.getDistribution(
+                states,
+                config.actionConfig().sigmaMin().floatValue(),
+                config.actionConfig().sigmaMax().floatValue()
+            );
+            Tensor newLogProbs = dist.logProb(actions); // log pi_new(a|s)
+            Tensor ratio = newLogProbs.sub(oldLogProbs.detach()).exp(); // (pi_new / pi_old)
+
+            Tensor detachedAdvantages = advantages.detach(); // Advantages don't depend on policy params being optimized here
+
+            Tensor surrogate1 = ratio.mul(detachedAdvantages);
+            Tensor surrogate2 = ratio.clip(
+                1.0f - config.hyperparams().ppoClip().floatValue(),
+                1.0f + config.hyperparams().ppoClip().floatValue()
+            ).mul(detachedAdvantages);
+
+            Tensor policyLoss = Tensor.min(surrogate1, surrogate2).mean().neg();
+
+            if (config.hyperparams().entropyBonus().floatValue() > 0) {
+                Tensor entropy = dist.entropy().mean();
+                policyLoss = policyLoss.sub(entropy.mul(config.hyperparams().entropyBonus().floatValue()));
+            }
+
+            policyGradQueue.clear();
+            policyLoss.minimize(policyGradQueue);
+            policyGradQueue.optimize(policyOptimizer);
+        }
+        incrementUpdateCount();
+    }
+
+    private record GAEResult(Tensor advantages, Tensor valueTargets) {}
+
+    private GAEResult computeGAE(List<Experience2> batch, Tensor valuesAtTimesteps, double valueOfLastNextState) {
+        int n = batch.size();
+        double[] advantages = new double[n];
+        double[] valueFunctionTargets = new double[n];
+
+        double gaeAccumulator = 0; // This is A_hat_GAE for t+1 when calculating for t
+        float gamma = config.hyperparams().gamma().floatValue();
+        float lambda = config.hyperparams().lambda().floatValue();
+
+        for (int t = n - 1; t >= 0; t--) {
+            Experience2 exp = batch.get(t);
+            double currentTimestepValue = valuesAtTimesteps.data(t,0); // V(s_t)
+
+            // V(s_{t+1})
+            double nextTimestepValue;
+            if (exp.done()) {
+                nextTimestepValue = 0; // Terminal state, V(s_{t+1}) is 0
+            } else if (t == n - 1) {
+                nextTimestepValue = valueOfLastNextState; // V(s_N) for last element from batch
+            } else {
+                nextTimestepValue = valuesAtTimesteps.data(t + 1, 0); // V(s_{t+1}) for non-last elements
+            }
+
+            double tdError = exp.reward() + gamma * nextTimestepValue - currentTimestepValue;
+            gaeAccumulator = tdError + gamma * lambda * gaeAccumulator * (exp.done() ? 0.0 : 1.0); // if done, next GAE is 0
+            advantages[t] = gaeAccumulator;
+            valueFunctionTargets[t] = advantages[t] + currentTimestepValue; // R_t for value net = A_t + V(s_t)
+        }
+        return new GAEResult(Tensor.row(advantages).transpose(), Tensor.row(valueFunctionTargets).transpose());
+    }
+
+    @Override public Object getPolicy() { return this.policy; }
+    @Override public Object getValueFunction() { return this.valueFunction; }
+    @Override public Object getConfig() { return this.config; }
+
+    @Override
+    public void setTrainingMode(boolean training) {
+        super.setTrainingMode(training);
+        this.policy.train(training);
+        this.valueFunction.train(training);
+        if (!training) { // If switching to eval mode, clear any partial trajectory
+            this.memory.clear();
+        }
+    }
+
+    @Override public void clearMemory() { this.memory.clear(); }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/PolicyGradientAgent.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/PolicyGradientAgent.java
@@ -1,0 +1,120 @@
+package jcog.tensor.rl.agents.pg;
+
+import jcog.tensor.Tensor;
+import jcog.tensor.rl.pg.util.Experience2; // Assuming Experience2 will be used or adapted
+
+/**
+ * Core interface for Policy Gradient (PG) reinforcement learning agents.
+ * This interface defines the common functionality expected from all PG agent implementations,
+ * facilitating interaction with environments and training loops.
+ *
+ * Implementations are expected to handle their own internal state, including networks,
+ * optimizers, and memory buffers, configured typically via constructor injection.
+ */
+public interface PolicyGradientAgent {
+
+    /**
+     * Selects an action based on the current state observation.
+     * The method of action selection may vary depending on whether the agent is in training
+     * or evaluation mode, and whether a deterministic or stochastic action is requested.
+     *
+     * @param state The current state representation, typically a {@link Tensor}.
+     * @param deterministic If true, the agent should select the action that it currently
+     *                      believes to be optimal (e.g., the mean of a policy distribution).
+     *                      If false, the agent should sample an action from its policy distribution,
+     *                      allowing for exploration.
+     * @return An array of doubles representing the selected action. The dimensionality
+     *         should match the action space of the environment.
+     */
+    double[] selectAction(Tensor state, boolean deterministic);
+
+    /**
+     * Records an experience transition, which consists of the state, action, reward,
+     * next state, and done flag.
+     * This method is responsible for storing the experience in the agent's memory buffer.
+     * Depending on the agent's learning strategy (e.g., on-policy vs. off-policy) and
+     * buffer status (e.g., full), this method might also trigger a learning update.
+     *
+     * @param experience The {@link Experience2} tuple representing the transition.
+     *                   For PPO agents, this experience should include the log probability
+     *                   of the action taken (oldLogProb).
+     */
+    void recordExperience(Experience2 experience);
+
+    /**
+     * Performs a learning update step for the agent.
+     * This typically involves sampling data from the memory buffer, computing gradients
+     * based on the agent's algorithm (e.g., REINFORCE, VPG, PPO), and updating
+     * the parameters of its internal networks (policy, value function).
+     *
+     * @param totalSteps The total number of environment steps taken so far. This can be
+     *                   used for scheduling purposes, such as annealing learning rates or
+     *                   other hyperparameters, or for logging. May not be used by all agents.
+     */
+    void update(long totalSteps);
+
+    /**
+     * Retrieves the policy network (actor) of the agent.
+     * The returned object is generally an instance of a class from {@code jcog.tensor.Models}
+     * (e.g., {@link jcog.tensor.rl.agents.pg.networks.GaussianPolicyNet})
+     * that can be applied to a state tensor to produce action parameters or a distribution.
+     * Exposing this allows for inspection and direct use if needed (e.g., by a GUI or for analysis).
+     *
+     * @return The policy network object. Type is {@code Object} for interface flexibility;
+     *         concrete implementations will return specific network types.
+     */
+    Object getPolicy();
+
+    /**
+     * Retrieves the value function network (critic) of the agent, if applicable.
+     * Some policy gradient agents, like basic REINFORCE, do not use an explicit value function network.
+     * For agents like VPG or PPO, this returns the network that estimates state values.
+     *
+     * @return The value function network object (e.g., {@link jcog.tensor.rl.agents.pg.networks.ValueNet}),
+     *         or {@code null} if the agent does not use one.
+     */
+    Object getValueFunction();
+
+    /**
+     * Gets the configuration object used by the agent.
+     * This object encapsulates all hyperparameters and structural settings for the agent,
+     * its networks, and memory. (e.g., {@link jcog.tensor.rl.agents.pg.configs.PPOAgentConfig}).
+     *
+     * @return The agent's configuration object. Type is {@code Object} for interface flexibility.
+     */
+    Object getConfig();
+
+    /**
+     * Indicates whether the agent is currently in training mode.
+     * In training mode, agents may perform exploration, update networks, and accumulate gradients.
+     * In evaluation mode (not training), agents typically act deterministically or with minimal exploration
+     * and do not update their parameters.
+     *
+     * @return {@code true} if the agent is in training mode, {@code false} otherwise.
+     */
+    boolean isTrainingMode();
+
+    /**
+     * Sets the agent's operational mode.
+     *
+     * @param training {@code true} to set the agent to training mode,
+     *                 {@code false} for evaluation/inference mode.
+     *                 This should also propagate the mode to internal networks.
+     */
+    void setTrainingMode(boolean training);
+
+    /**
+     * Clears any accumulated experiences from the agent's memory buffer.
+     * This is often called after a learning update for on-policy agents or to reset state.
+     */
+    void clearMemory();
+
+    /**
+     * Returns the total number of learning updates that have been performed by the agent.
+     * This can be useful for tracking training progress.
+     *
+     * @return The count of learning updates.
+     */
+    long getUpdateCount();
+
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/ReinforceAgent.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/ReinforceAgent.java
@@ -1,0 +1,165 @@
+package jcog.tensor.rl.agents.pg;
+
+import jcog.tensor.Tensor;
+import jcog.tensor.rl.agents.pg.configs.ReinforceAgentConfig;
+import jcog.tensor.rl.agents.pg.memory.AgentMemory;
+import jcog.tensor.rl.agents.pg.memory.OnPolicyBuffer;
+import jcog.tensor.rl.agents.pg.networks.GaussianPolicyNet;
+import jcog.tensor.rl.agents.pg.util.AgentUtils; // For normalize and GaussianDistribution
+import jcog.tensor.rl.pg.util.Experience2; // Still using this Experience DTO
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class ReinforceAgent extends BasePolicyGradientAgent {
+
+    public final ReinforceAgentConfig config;
+    public final GaussianPolicyNet policy;
+    public final Tensor.Optimizer policyOptimizer;
+    public final AgentMemory memory;
+
+    private final Tensor.GradQueue policyGradQueue;
+
+    public ReinforceAgent(ReinforceAgentConfig config, int stateDim, int actionDim) {
+        Objects.requireNonNull(config, "Agent configuration cannot be null");
+        this.config = config;
+
+        this.policy = new GaussianPolicyNet(config.policyNetworkConfig(), stateDim, actionDim);
+        this.policyOptimizer = config.policyNetworkConfig().optimizer().build();
+
+        // Ensure memoryConfig.episodeLength() is not null due to ReinforceAgentConfig constructor validation
+        this.memory = new OnPolicyBuffer(config.memoryConfig().episodeLength().intValue());
+
+        this.policyGradQueue = new Tensor.GradQueue();
+
+        setTrainingMode(true); // Initialize training mode by default
+    }
+
+    @Override
+    public double[] selectAction(Tensor state, boolean deterministic) {
+        // Policy is set to eval mode (train(false)) if agent is not in training mode by setTrainingMode method.
+        // No need to toggle here unless specific per-action logic is needed outside agent's global training state.
+        try (var noGrad = Tensor.noGrad()) { // Ensure no gradients are computed during action selection
+            AgentUtils.GaussianDistribution dist = policy.getDistribution(
+                state,
+                config.actionConfig().sigmaMin().floatValue(),
+                config.actionConfig().sigmaMax().floatValue()
+            );
+            Tensor action = dist.sample(deterministic);
+            // Assuming actions should be clipped to a standard range like [-1, 1] for continuous control.
+            return action.clipUnitPolar().array();
+        }
+    }
+
+    @Override
+    public void recordExperience(Experience2 experience) {
+        Objects.requireNonNull(experience, "Experience cannot be null");
+        if (!this.trainingMode) {
+            // If not in training mode, typically don't record experience or update.
+            // However, some evaluation phases might still want to log/store for analysis.
+            // For REINFORCE, training updates are episode-based, so this check is crucial.
+            return;
+        }
+        this.memory.add(experience);
+
+        if (experience.done()) {
+            if (this.memory.size() > 0) {
+                update(0); // totalSteps is not strictly needed by this REINFORCE update logic
+            }
+            // Crucially, clear memory after episode processing for on-policy REINFORCE
+            this.memory.clear();
+        }
+    }
+
+    @Override
+    public void update(long totalSteps) {
+        if (!this.trainingMode || this.memory.size() == 0) {
+            return;
+        }
+
+        List<Experience2> episode = this.memory.getAll(); // Gets a copy
+
+        Tensor returns = computeReturns(episode);
+
+        List<Tensor> statesList = episode.stream().map(Experience2::state).collect(Collectors.toList());
+        List<Tensor> actionsList = episode.stream().map(e -> Tensor.row(e.action())).collect(Collectors.toList());
+
+        // It's generally more efficient to batch forward passes if possible.
+        Tensor statesBatch = Tensor.concatRows(statesList);
+        Tensor actionsBatch = Tensor.concatRows(actionsList);
+
+        AgentUtils.GaussianDistribution dist = policy.getDistribution(
+            statesBatch,
+            config.actionConfig().sigmaMin().floatValue(),
+            config.actionConfig().sigmaMax().floatValue()
+        );
+        Tensor logProbs = dist.logProb(actionsBatch);
+
+        // Ensure returns tensor is compatible for element-wise multiplication (e.g., same shape or broadcastable)
+        // logProbs: (batch_size, 1), returns: (batch_size, 1)
+        Tensor policyLoss = logProbs.mul(returns).mean().neg();
+
+        if (config.hyperparams().entropyBonus().floatValue() > 0) {
+            Tensor entropy = dist.entropy().mean(); // entropy is per-timestep, so mean over batch
+            policyLoss = policyLoss.sub(entropy.mul(config.hyperparams().entropyBonus().floatValue()));
+        }
+
+        policyGradQueue.clear(); // Clear any old gradients
+        policyLoss.minimize(policyGradQueue);
+        policyGradQueue.optimize(policyOptimizer);
+
+        incrementUpdateCount();
+        // Memory is cleared in recordExperience after 'done' for REINFORCE.
+    }
+
+    private Tensor computeReturns(List<Experience2> episode) {
+        int n = episode.size();
+        double[] G = new double[n];
+        double currentReturn = 0;
+
+        for (int t = n - 1; t >= 0; t--) {
+            currentReturn = episode.get(t).reward() + config.hyperparams().gamma().floatValue() * currentReturn;
+            G[t] = currentReturn;
+        }
+
+        Tensor returnsTensor = Tensor.row(G).transpose();
+
+        if (config.hyperparams().normalizeReturns()) {
+            double[] returnsToNormalize = returnsTensor.array().clone();
+            AgentUtils.normalize(returnsToNormalize);
+            return Tensor.row(returnsToNormalize).transpose();
+        } else {
+            return returnsTensor;
+        }
+    }
+
+    @Override
+    public Object getPolicy() {
+        return this.policy;
+    }
+
+    @Override
+    public Object getValueFunction() {
+        return null;
+    }
+
+    @Override
+    public Object getConfig() {
+        return this.config;
+    }
+
+    @Override
+    public void setTrainingMode(boolean training) {
+        super.setTrainingMode(training);
+        this.policy.train(training);
+        if (!training) { // If switching to eval mode, good practice to clear any partial trajectory
+            this.memory.clear();
+        }
+    }
+
+    @Override
+    public void clearMemory() {
+        this.memory.clear();
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/VPGAgent.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/VPGAgent.java
@@ -1,0 +1,183 @@
+package jcog.tensor.rl.agents.pg;
+
+import jcog.tensor.Tensor;
+import jcog.tensor.rl.agents.pg.configs.VPGAgentConfig;
+import jcog.tensor.rl.agents.pg.memory.AgentMemory;
+import jcog.tensor.rl.agents.pg.memory.OnPolicyBuffer;
+import jcog.tensor.rl.agents.pg.networks.GaussianPolicyNet;
+import jcog.tensor.rl.agents.pg.networks.ValueNet;
+import jcog.tensor.rl.agents.pg.util.AgentUtils;
+import jcog.tensor.rl.pg.util.Experience2;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class VPGAgent extends BasePolicyGradientAgent {
+
+    public final VPGAgentConfig config;
+    public final GaussianPolicyNet policy;
+    public final ValueNet valueFunction;
+    public final Tensor.Optimizer policyOptimizer;
+    public final Tensor.Optimizer valueOptimizer;
+    public final AgentMemory memory;
+
+    private final Tensor.GradQueue policyGradQueue;
+    private final Tensor.GradQueue valueGradQueue;
+
+    public VPGAgent(VPGAgentConfig config, int stateDim, int actionDim) {
+        Objects.requireNonNull(config, "Agent configuration cannot be null");
+        this.config = config;
+
+        this.policy = new GaussianPolicyNet(config.policyNetworkConfig(), stateDim, actionDim);
+        this.valueFunction = new ValueNet(config.valueNetworkConfig(), stateDim);
+
+        this.policyOptimizer = config.policyNetworkConfig().optimizer().build();
+        this.valueOptimizer = config.valueNetworkConfig().optimizer().build();
+
+        this.memory = new OnPolicyBuffer(config.memoryConfig().episodeLength().intValue());
+
+        this.policyGradQueue = new Tensor.GradQueue();
+        this.valueGradQueue = new Tensor.GradQueue();
+
+        setTrainingMode(true); // Initialize training mode by default
+    }
+
+    @Override
+    public double[] selectAction(Tensor state, boolean deterministic) {
+        try (var noGrad = Tensor.noGrad()) {
+            AgentUtils.GaussianDistribution dist = policy.getDistribution(
+                state,
+                config.actionConfig().sigmaMin().floatValue(),
+                config.actionConfig().sigmaMax().floatValue()
+            );
+            Tensor action = dist.sample(deterministic);
+            return action.clipUnitPolar().array();
+        }
+    }
+
+    @Override
+    public void recordExperience(Experience2 experience) {
+        Objects.requireNonNull(experience, "Experience cannot be null");
+         if (!this.trainingMode) {
+            return; // Do not record or update if not in training mode
+        }
+        this.memory.add(experience);
+
+        if (experience.done()) {
+            if (this.memory.size() > 0) {
+                update(0); // totalSteps not critical for this VPG update logic
+            }
+            this.memory.clear(); // Clear memory after episode processing
+        }
+    }
+
+    @Override
+    public void update(long totalSteps) {
+        if (!this.trainingMode || this.memory.size() == 0) {
+            return;
+        }
+
+        List<Experience2> episode = this.memory.getAll(); // Get a copy
+
+        Tensor returns = computeReturns(episode);
+
+        List<Tensor> statesList = episode.stream().map(Experience2::state).collect(Collectors.toList());
+        Tensor statesBatch = Tensor.concatRows(statesList);
+
+        // 1. Update Value Function
+        Tensor predictedValues = this.valueFunction.apply(statesBatch);
+        Tensor valueLoss = predictedValues.loss(returns.detach(), Tensor.Loss.MeanSquared);
+
+        valueGradQueue.clear();
+        valueLoss.minimize(valueGradQueue);
+        valueGradQueue.optimize(valueOptimizer);
+
+        // 2. Calculate Advantages (A(s,a) = R_t - V(s_t))
+        Tensor advantages = returns.sub(predictedValues.detach());
+        if (config.hyperparams().normalizeAdvantages()) {
+            double[] advantagesArray = advantages.array().clone(); // Clone to normalize a copy
+            AgentUtils.normalize(advantagesArray);
+            advantages = Tensor.row(advantagesArray).transpose();
+        }
+
+        // 3. Update Policy
+        List<Tensor> actionsList = episode.stream().map(e -> Tensor.row(e.action())).collect(Collectors.toList());
+        Tensor actionsBatch = Tensor.concatRows(actionsList);
+
+        AgentUtils.GaussianDistribution dist = policy.getDistribution(
+            statesBatch,
+            config.actionConfig().sigmaMin().floatValue(),
+            config.actionConfig().sigmaMax().floatValue()
+        );
+        Tensor logProbs = dist.logProb(actionsBatch);
+
+        Tensor policyLoss = logProbs.mul(advantages).mean().neg();
+
+        if (config.hyperparams().entropyBonus().floatValue() > 0) {
+            Tensor entropy = dist.entropy().mean();
+            policyLoss = policyLoss.sub(entropy.mul(config.hyperparams().entropyBonus().floatValue()));
+        }
+
+        policyGradQueue.clear();
+        policyLoss.minimize(policyGradQueue);
+        policyGradQueue.optimize(policyOptimizer);
+
+        incrementUpdateCount();
+        // Memory is cleared in recordExperience after 'done' for VPG.
+    }
+
+    private Tensor computeReturns(List<Experience2> episode) {
+        int n = episode.size();
+        double[] G = new double[n];
+        double currentReturn = 0; // This is R_t or G_t in equations
+
+        // Iterate backwards through the episode to calculate discounted returns
+        for (int t = n - 1; t >= 0; t--) {
+            currentReturn = episode.get(t).reward() + config.hyperparams().gamma().floatValue() * currentReturn;
+            G[t] = currentReturn;
+        }
+
+        Tensor returnsTensor = Tensor.row(G).transpose(); // Shape [n, 1]
+
+        // Optional normalization of returns (targets for value function)
+        // This is less common for VPG targets than normalizing advantages, but supported by config.
+        if (config.hyperparams().normalizeReturns()) {
+             double[] returnsToNormalize = returnsTensor.array().clone();
+             AgentUtils.normalize(returnsToNormalize);
+             return Tensor.row(returnsToNormalize).transpose();
+        } else {
+            return returnsTensor;
+        }
+    }
+
+    @Override
+    public Object getPolicy() {
+        return this.policy;
+    }
+
+    @Override
+    public Object getValueFunction() {
+        return this.valueFunction;
+    }
+
+    @Override
+    public Object getConfig() {
+        return this.config;
+    }
+
+    @Override
+    public void setTrainingMode(boolean training) {
+        super.setTrainingMode(training);
+        this.policy.train(training);
+        this.valueFunction.train(training);
+        if (!training) { // If switching to eval mode, clear any partial trajectory
+            this.memory.clear();
+        }
+    }
+
+    @Override
+    public void clearMemory() {
+        this.memory.clear();
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/ActionConfig.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/ActionConfig.java
@@ -1,0 +1,153 @@
+package jcog.tensor.rl.agents.pg.configs;
+
+import jcog.signal.FloatRange; // Assuming this exists
+
+import java.util.Objects;
+
+/**
+ * Configuration for action selection properties of an RL agent.
+ * This includes the type of action distribution, parameters for stochastic policies (like sigma bounds),
+ * and configuration for action noise.
+ *
+ * @param distribution The type of probability distribution used by the policy (e.g., Gaussian for continuous actions).
+ * @param sigmaMin Minimum standard deviation for Gaussian policies. Ensures exploration doesn't collapse.
+ * @param sigmaMax Maximum standard deviation for Gaussian policies. Prevents overly erratic exploration.
+ * @param noise Configuration for adding noise to actions, often used for exploration in deterministic policies.
+ */
+public record ActionConfig(
+    Distribution distribution,
+    FloatRange sigmaMin,
+    FloatRange sigmaMax,
+    NoiseConfig noise
+) {
+    /**
+     * Defines the type of probability distribution the policy will use.
+     */
+    public enum Distribution {
+        /** For continuous action spaces, typically outputting mean and standard deviation. */
+        GAUSSIAN,
+        /** For policies that output a single action value directly, without a stochastic component from a distribution. */
+        DETERMINISTIC
+    }
+
+    /**
+     * Configuration for action noise, typically used for exploration with deterministic policies
+     * or sometimes to augment stochastic policies.
+     *
+     * @param type The type of noise to apply (e.g., Gaussian, Ornstein-Uhlenbeck).
+     * @param stddev The standard deviation of the noise. For OU noise, this might be an initial magnitude.
+     */
+    public record NoiseConfig(
+        Type type,
+        FloatRange stddev
+    ) {
+        /**
+         * Defines the type of noise process.
+         */
+        public enum Type {
+            /** No action noise. */
+            NONE,
+            /** Simple Gaussian (normal) noise. */
+            GAUSSIAN,
+            /** Ornstein-Uhlenbeck process, often used for temporally correlated noise in continuous control. */
+            OU
+        }
+
+        /** Default noise type: Gaussian. */
+        public static final Type DEFAULT_NOISE_TYPE = Type.GAUSSIAN;
+        /** Default noise standard deviation: 0.1, range [0, 1]. */
+        public static final FloatRange DEFAULT_NOISE_STDDEV = new FloatRange(0.1f, 0.0f, 1.0f, 0.1f);
+
+        /**
+         * Validates noise configuration.
+         */
+        public NoiseConfig {
+            Objects.requireNonNull(type, "Noise type cannot be null");
+            Objects.requireNonNull(stddev, "Noise stddev cannot be null");
+            if (stddev.floatValue() < 0 && type != Type.NONE) {
+                throw new IllegalArgumentException("Noise stddev must be non-negative for GAUSSIAN or OU noise.");
+            }
+        }
+
+        /**
+         * Creates a default NoiseConfig (Gaussian noise with stddev 0.1).
+         */
+        public NoiseConfig() {
+            this(DEFAULT_NOISE_TYPE, DEFAULT_NOISE_STDDEV);
+        }
+
+        /** Returns a new NoiseConfig with the specified type. */
+        public NoiseConfig withType(Type type) { return new NoiseConfig(type, this.stddev); }
+        /** Returns a new NoiseConfig with the specified stddev range. */
+        public NoiseConfig withStddev(FloatRange stddev) { return new NoiseConfig(this.type, stddev); }
+        /** Returns a new NoiseConfig with the specified stddev value, retaining existing min/max from the current stddev range. */
+        public NoiseConfig withStddev(float stddevValue) {
+            return new NoiseConfig(this.type, new FloatRange(stddevValue, this.stddev.min(), this.stddev.max(), stddevValue));
+        }
+    }
+
+    /** Default action distribution: Gaussian. */
+    public static final Distribution DEFAULT_ACTION_DISTRIBUTION = Distribution.GAUSSIAN;
+    /** Default minimum sigma for Gaussian policies: 0.001, range [1e-6, 1.0]. */
+    public static final FloatRange DEFAULT_SIGMA_MIN = new FloatRange(1e-3f, 1e-6f, 1.0f, 1e-3f);
+    /** Default maximum sigma for Gaussian policies: 1.0, range [0.1, 10.0]. */
+    public static final FloatRange DEFAULT_SIGMA_MAX = new FloatRange(1.0f, 0.1f, 10.0f, 1.0f);
+    /** Default noise configuration. */
+    public static final NoiseConfig DEFAULT_NOISE_CONFIG = new NoiseConfig();
+
+    /**
+     * Validates action configuration.
+     */
+    public ActionConfig {
+        Objects.requireNonNull(distribution, "Action distribution cannot be null");
+        Objects.requireNonNull(sigmaMin, "sigmaMin cannot be null");
+        Objects.requireNonNull(sigmaMax, "sigmaMax cannot be null");
+        Objects.requireNonNull(noise, "Noise config cannot be null");
+
+        if (distribution == Distribution.GAUSSIAN) {
+            if (sigmaMin.floatValue() <= 0) throw new IllegalArgumentException("sigmaMin must be positive for GAUSSIAN distribution");
+            if (sigmaMax.floatValue() <= 0) throw new IllegalArgumentException("sigmaMax must be positive for GAUSSIAN distribution");
+            if (sigmaMin.floatValue() >= sigmaMax.floatValue()) {
+                throw new IllegalArgumentException("sigmaMin must be less than sigmaMax for GAUSSIAN distribution");
+            }
+        }
+    }
+
+    /**
+     * Creates a default ActionConfig.
+     * Uses Gaussian distribution, default sigma ranges, and default noise settings.
+     */
+    public ActionConfig() {
+        this(DEFAULT_ACTION_DISTRIBUTION, DEFAULT_SIGMA_MIN, DEFAULT_SIGMA_MAX, DEFAULT_NOISE_CONFIG);
+    }
+
+    // Withers for ActionConfig
+    /** Returns a new ActionConfig with the specified distribution. */
+    public ActionConfig withDistribution(Distribution distribution) { return new ActionConfig(distribution, sigmaMin, sigmaMax, noise); }
+    /** Returns a new ActionConfig with the specified sigmaMin range. */
+    public ActionConfig withSigmaMin(FloatRange sigmaMin) {
+        if (this.distribution == Distribution.GAUSSIAN && sigmaMin.floatValue() >= this.sigmaMax.floatValue()) {
+            throw new IllegalArgumentException("sigmaMin must be less than current sigmaMax");
+        }
+        return new ActionConfig(distribution, sigmaMin, sigmaMax, noise);
+    }
+    /** Returns a new ActionConfig with the specified sigmaMin value, retaining current min/max from its range. */
+    public ActionConfig withSigmaMin(float sigmaMinValue) { return withSigmaMin(new FloatRange(sigmaMinValue, this.sigmaMin.min(), this.sigmaMin.max(), sigmaMinValue)); }
+    /** Returns a new ActionConfig with the specified sigmaMax range. */
+    public ActionConfig withSigmaMax(FloatRange sigmaMax) {
+         if (this.distribution == Distribution.GAUSSIAN && this.sigmaMin.floatValue() >= sigmaMax.floatValue()) {
+            throw new IllegalArgumentException("current sigmaMin must be less than sigmaMax");
+        }
+        return new ActionConfig(distribution, sigmaMin, sigmaMax, noise);
+    }
+    /** Returns a new ActionConfig with the specified sigmaMax value, retaining current min/max from its range. */
+    public ActionConfig withSigmaMax(float sigmaMaxValue) { return withSigmaMax(new FloatRange(sigmaMaxValue, this.sigmaMax.min(), this.sigmaMax.max(), sigmaMaxValue)); }
+    /** Returns a new ActionConfig with the specified noise configuration. */
+    public ActionConfig withNoiseConfig(NoiseConfig noise) { return new ActionConfig(distribution, sigmaMin, sigmaMax, noise); }
+    /** Returns a new ActionConfig with the specified noise type. */
+    public ActionConfig withNoiseType(NoiseConfig.Type noiseType) { return new ActionConfig(distribution, sigmaMin, sigmaMax, this.noise.withType(noiseType)); }
+    /** Returns a new ActionConfig with the specified noise stddev range. */
+    public ActionConfig withNoiseStddev(FloatRange noiseStddevRange) { return new ActionConfig(distribution, sigmaMin, sigmaMax, this.noise.withStddev(noiseStddevRange)); }
+    /** Returns a new ActionConfig with the specified noise stddev value. */
+    public ActionConfig withNoiseStddev(float noiseStddevValue) { return new ActionConfig(distribution, sigmaMin, sigmaMax, this.noise.withStddev(noiseStddevValue)); }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/HyperparamConfig.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/HyperparamConfig.java
@@ -1,0 +1,111 @@
+package jcog.tensor.rl.agents.pg.configs;
+
+import jcog.signal.FloatRange;
+import jcog.signal.IntRange; // Assuming IntRange exists similarly to FloatRange
+
+import java.util.Objects;
+
+/**
+ * Configuration for common hyperparameters used across various Policy Gradient agents.
+ * These parameters control aspects of the learning process such as discount rates,
+ * learning rates, and algorithm-specific settings like PPO clipping or SAC entropy.
+ *
+ * <p>Fields are {@code public final} as records are immutable, facilitating GUI access and inspection.
+ * Uses {@link FloatRange} and {@link IntRange} for numeric parameters to support GUI rendering,
+ * validation, and definition of sensible min/max/default values.</p>
+ *
+ * @param gamma Discount factor for future rewards. Typically close to 1.0 (e.g., 0.99).
+ * @param lambda Parameter for Generalized Advantage Estimation (GAE). Typically between 0.9 and 1.0.
+ * @param entropyBonus Coefficient for the entropy bonus term in the policy loss, encouraging exploration.
+ * @param ppoClip Clipping parameter for PPO's surrogate objective. Limits the policy update step.
+ * @param tau Target network update rate (for soft updates in algorithms like DDPG or SAC). (1-tau)*target + tau*source.
+ * @param policyLR Learning rate for the policy network optimizer.
+ * @param valueLR Learning rate for the value network optimizer.
+ * @param epochs Number of optimization epochs to run on a collected batch of data (used in PPO).
+ * @param policyUpdateFreq Frequency of policy updates relative to critic updates (e.g., in DDPG/SAC, update policy every N critic updates).
+ * @param normalizeAdvantages Whether to normalize advantages before using them in the policy loss.
+ * @param normalizeReturns Whether to normalize returns (often targets for value function).
+ * @param learnableAlpha For SAC, whether the entropy temperature alpha is a learnable parameter.
+ */
+public record HyperparamConfig(
+    FloatRange gamma,
+    FloatRange lambda,
+    FloatRange entropyBonus,
+    FloatRange ppoClip,
+    FloatRange tau,
+    FloatRange policyLR,
+    FloatRange valueLR,
+    IntRange epochs,
+    IntRange policyUpdateFreq,
+    boolean normalizeAdvantages,
+    boolean normalizeReturns,
+    boolean learnableAlpha
+) {
+
+    /** Default discount factor (gamma): 0.99. Range [0.0, 1.0]. */
+    public static final FloatRange DEFAULT_GAMMA = new FloatRange(0.99f, 0.0f, 1.0f, 0.99f);
+    /** Default GAE lambda: 0.95. Range [0.0, 1.0]. */
+    public static final FloatRange DEFAULT_LAMBDA = new FloatRange(0.95f, 0.0f, 1.0f, 0.95f);
+    /** Default entropy bonus coefficient: 0.01. Range [0.0, 1.0]. */
+    public static final FloatRange DEFAULT_ENTROPY_BONUS = new FloatRange(0.01f, 0.0f, 1.0f, 0.01f);
+    /** Default PPO clipping epsilon: 0.2. Range [0.01, 0.5]. */
+    public static final FloatRange DEFAULT_PPO_CLIP = new FloatRange(0.2f, 0.01f, 0.5f, 0.2f);
+    /** Default target network soft update rate (tau): 0.005. Range [0.0, 1.0]. */
+    public static final FloatRange DEFAULT_TAU = new FloatRange(0.005f, 0.0f, 1.0f, 0.005f);
+    /** Default policy learning rate: 3e-4. Range [1e-6, 1e-2]. */
+    public static final FloatRange DEFAULT_POLICY_LR = new FloatRange(3e-4f, 1e-6f, 1e-2f, 3e-4f);
+    /** Default value function learning rate: 1e-3. Range [1e-6, 1e-2]. */
+    public static final FloatRange DEFAULT_VALUE_LR = new FloatRange(1e-3f, 1e-6f, 1e-2f, 1e-3f);
+    /** Default number of PPO epochs: 10. Range [1, 100]. */
+    public static final IntRange DEFAULT_EPOCHS = new IntRange(10, 1, 100, 10);
+    /** Default policy update frequency (e.g., for DDPG/SAC): 1 (update policy as often as critic). Range [1, 1000]. */
+    public static final IntRange DEFAULT_POLICY_UPDATE_FREQ = new IntRange(1, 1, 1000, 1);
+    /** Default for normalizing advantages: true. */
+    public static final boolean DEFAULT_NORMALIZE_ADVANTAGES = true;
+    /** Default for normalizing returns: false. */
+    public static final boolean DEFAULT_NORMALIZE_RETURNS = false;
+    /** Default for learnable alpha (SAC entropy temperature): false. */
+    public static final boolean DEFAULT_LEARNABLE_ALPHA = false;
+
+    /**
+     * Validates hyperparameter configuration.
+     * Ensures that all range-based parameters are within their expected bounds and that
+     * learning rates and other critical values are positive.
+     */
+    public HyperparamConfig {
+        Objects.requireNonNull(gamma, "gamma cannot be null");
+        Objects.requireNonNull(lambda, "lambda cannot be null");
+        Objects.requireNonNull(entropyBonus, "entropyBonus cannot be null");
+        Objects.requireNonNull(ppoClip, "ppoClip cannot be null");
+        Objects.requireNonNull(tau, "tau cannot be null");
+        Objects.requireNonNull(policyLR, "policyLR cannot be null");
+        Objects.requireNonNull(valueLR, "valueLR cannot be null");
+        Objects.requireNonNull(epochs, "epochs cannot be null");
+        Objects.requireNonNull(policyUpdateFreq, "policyUpdateFreq cannot be null");
+
+        if (gamma.floatValue() < 0.0f || gamma.floatValue() > 1.0f) throw new IllegalArgumentException("gamma must be in [0, 1]");
+        if (lambda.floatValue() < 0.0f || lambda.floatValue() > 1.0f) throw new IllegalArgumentException("lambda must be in [0, 1]");
+        // entropyBonus can be 0
+        if (tau.floatValue() < 0.0f || tau.floatValue() > 1.0f) throw new IllegalArgumentException("tau must be in [0, 1]");
+        if (policyLR.floatValue() <= 0) throw new IllegalArgumentException("policyLR must be positive");
+        if (valueLR.floatValue() <= 0) throw new IllegalArgumentException("valueLR must be positive");
+        if (epochs.intValue() <= 0) throw new IllegalArgumentException("epochs must be positive for PPO-like algorithms");
+        if (policyUpdateFreq.intValue() <= 0) throw new IllegalArgumentException("policyUpdateFreq must be positive");
+        if (ppoClip.floatValue() <= 0) throw new IllegalArgumentException("ppoClip must be positive for PPO");
+    }
+
+    /**
+     * Creates a {@code HyperparamConfig} with default values for all hyperparameters.
+     */
+    public HyperparamConfig() {
+        this(
+            DEFAULT_GAMMA, DEFAULT_LAMBDA, DEFAULT_ENTROPY_BONUS, DEFAULT_PPO_CLIP, DEFAULT_TAU,
+            DEFAULT_POLICY_LR, DEFAULT_VALUE_LR, DEFAULT_EPOCHS, DEFAULT_POLICY_UPDATE_FREQ,
+            DEFAULT_NORMALIZE_ADVANTAGES, DEFAULT_NORMALIZE_RETURNS, DEFAULT_LEARNABLE_ALPHA
+        );
+    }
+
+    // Note: "Wither" methods are omitted for brevity but can be added if needed
+    // for more convenient modification of individual parameters while maintaining immutability.
+    // Example: public HyperparamConfig withGamma(FloatRange gamma) { return new HyperparamConfig(gamma, ...); }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/MemoryConfig.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/MemoryConfig.java
@@ -1,0 +1,144 @@
+package jcog.tensor.rl.agents.pg.configs;
+
+import jcog.signal.IntRange; // Assuming this exists
+
+import java.util.Objects;
+
+/**
+ * Configuration for the memory system of an RL agent.
+ * This can define settings for on-policy data collection (like episode or batch length)
+ * and/or for off-policy replay buffers (like capacity and sampling batch size).
+ *
+ * @param episodeLength For on-policy algorithms, this defines the number of steps collected
+ *                      before an update is performed (e.g., PPO's rollout length).
+ *                      Can be {@code null} if the agent is purely off-policy and uses only a replay buffer.
+ * @param replayBuffer Configuration for an off-policy replay buffer.
+ *                     Can be {@code null} if the agent is purely on-policy.
+ */
+public record MemoryConfig(
+    IntRange episodeLength,
+    ReplayBufferConfig replayBuffer
+) {
+    /**
+     * Configuration for an off-policy experience replay buffer.
+     *
+     * @param capacity The maximum number of experiences the buffer can store.
+     * @param batchSize The number of experiences to sample from the buffer during each learning update.
+     */
+    public record ReplayBufferConfig(
+        IntRange capacity,
+        IntRange batchSize
+    ) {
+        /** Default replay buffer capacity: 100,000. Range [1000, 1,000,000]. */
+        public static final IntRange DEFAULT_CAPACITY = new IntRange(100_000, 1_000, 1_000_000, 100_000);
+        /** Default replay buffer sample batch size: 256. Range [32, 2048]. */
+        public static final IntRange DEFAULT_BATCH_SIZE = new IntRange(256, 32, 2048, 256);
+
+        /**
+         * Validates replay buffer configuration.
+         */
+        public ReplayBufferConfig {
+            Objects.requireNonNull(capacity, "Capacity cannot be null");
+            Objects.requireNonNull(batchSize, "Batch size cannot be null");
+            if (capacity.intValue() <= 0) throw new IllegalArgumentException("Buffer capacity must be positive");
+            if (batchSize.intValue() <= 0) throw new IllegalArgumentException("Batch size must be positive");
+            if (batchSize.intValue() > capacity.intValue()) {
+                throw new IllegalArgumentException("Batch size cannot be larger than buffer capacity");
+            }
+        }
+
+        /**
+         * Creates a default {@code ReplayBufferConfig}.
+         */
+        public ReplayBufferConfig() {
+            this(DEFAULT_CAPACITY, DEFAULT_BATCH_SIZE);
+        }
+
+        /** Returns a new ReplayBufferConfig with the specified capacity range. */
+        public ReplayBufferConfig withCapacity(IntRange capacity) { return new ReplayBufferConfig(capacity, this.batchSize); }
+        /** Returns a new ReplayBufferConfig with the specified capacity value, retaining current min/max from its range. */
+        public ReplayBufferConfig withCapacity(int capacityValue) {
+            return new ReplayBufferConfig(new IntRange(capacityValue, this.capacity.min(), this.capacity.max(), capacityValue), this.batchSize);
+        }
+        /** Returns a new ReplayBufferConfig with the specified batch size range. */
+        public ReplayBufferConfig withBatchSize(IntRange batchSize) { return new ReplayBufferConfig(this.capacity, batchSize); }
+        /** Returns a new ReplayBufferConfig with the specified batch size value, retaining current min/max from its range. */
+        public ReplayBufferConfig withBatchSize(int batchSizeValue) {
+            return new ReplayBufferConfig(this.capacity, new IntRange(batchSizeValue, this.batchSize.min(), this.batchSize.max(), batchSizeValue));
+        }
+    }
+
+    /** Default episode/batch length for on-policy data collection: 2048. Range [64, 8192]. */
+    public static final IntRange DEFAULT_EPISODE_LENGTH = new IntRange(2048, 64, 8192, 2048);
+    /** Default replay buffer configuration (used if an agent supports off-policy learning). */
+    public static final ReplayBufferConfig DEFAULT_REPLAY_BUFFER_CONFIG = new ReplayBufferConfig();
+
+    /**
+     * Validates memory configuration.
+     * Ensures that at least one memory mechanism (on-policy episode length or off-policy replay buffer) is configured.
+     */
+    public MemoryConfig {
+        if (episodeLength == null && replayBuffer == null) {
+            throw new IllegalArgumentException("Either episodeLength or replayBuffer must be configured.");
+        }
+        if (episodeLength != null && episodeLength.intValue() <= 0 && replayBuffer == null) {
+            throw new IllegalArgumentException("Episode length must be positive if replay buffer is not used.");
+        }
+    }
+
+    /**
+     * Constructor for on-policy agents, specifying only the episode length.
+     * @param episodeLength The number of steps to collect before an update.
+     */
+    public MemoryConfig(IntRange episodeLength) {
+        this(episodeLength, null);
+    }
+
+    /**
+     * Constructor for on-policy agents, specifying only the episode length as an integer.
+     * Uses default min/max for the IntRange.
+     * @param episodeLengthValue The number of steps to collect before an update.
+     */
+    public MemoryConfig(int episodeLengthValue) {
+        this(new IntRange(episodeLengthValue, DEFAULT_EPISODE_LENGTH.min(), DEFAULT_EPISODE_LENGTH.max(), episodeLengthValue), null);
+    }
+
+    /**
+     * Constructor for off-policy agents, specifying only the replay buffer configuration.
+     * @param replayBufferConfig Configuration for the replay buffer.
+     */
+    public MemoryConfig(ReplayBufferConfig replayBufferConfig) {
+        this(null, replayBufferConfig);
+    }
+
+    /**
+     * Default constructor. Initializes with a default episode length (for on-policy)
+     * and a default replay buffer configuration (for potential off-policy use).
+     * Specific agents should typically use a more tailored constructor.
+     */
+    public MemoryConfig() {
+        this(DEFAULT_EPISODE_LENGTH, DEFAULT_REPLAY_BUFFER_CONFIG);
+    }
+
+    // Withers for MemoryConfig
+    /** Returns a new MemoryConfig with the specified episode length range. */
+    public MemoryConfig withEpisodeLength(IntRange episodeLength) { return new MemoryConfig(episodeLength, this.replayBuffer); }
+    /** Returns a new MemoryConfig with the specified episode length value. */
+    public MemoryConfig withEpisodeLength(int episodeLengthValue) {
+        IntRange currentMinMax = this.episodeLength != null ? this.episodeLength : DEFAULT_EPISODE_LENGTH;
+        return new MemoryConfig(new IntRange(episodeLengthValue,
+            currentMinMax.min(), currentMinMax.max(), episodeLengthValue), this.replayBuffer);
+    }
+    /** Returns a new MemoryConfig with the specified replay buffer configuration. */
+    public MemoryConfig withReplayBufferConfig(ReplayBufferConfig replayBuffer) { return new MemoryConfig(this.episodeLength, replayBuffer); }
+    /** Returns a new MemoryConfig with updated replay buffer capacity. */
+    public MemoryConfig withReplayBufferCapacity(int capacityValue) {
+        ReplayBufferConfig currentRB = this.replayBuffer == null ? new ReplayBufferConfig() : this.replayBuffer;
+        return new MemoryConfig(this.episodeLength, currentRB.withCapacity(capacityValue));
+    }
+    /** Returns a new MemoryConfig with updated replay buffer batch size. */
+    public MemoryConfig withReplayBufferBatchSize(int batchSizeValue) {
+        ReplayBufferConfig currentRB = this.replayBuffer == null ? new ReplayBufferConfig() : this.replayBuffer;
+        return new MemoryConfig(this.episodeLength, currentRB.withBatchSize(batchSizeValue));
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/NetworkConfig.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/NetworkConfig.java
@@ -1,0 +1,85 @@
+package jcog.tensor.rl.agents.pg.configs;
+
+import jcog.signal.FloatRange; // Assuming this exists
+import jcog.tensor.Tensor;
+import jcog.util.ArrayUtil; // Assuming this is available
+
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+
+public record NetworkConfig(
+    int[] hiddenLayers, // Keep as int[]
+    UnaryOperator<Tensor> activation, // Keep as is
+    UnaryOperator<Tensor> outputActivation, // Keep as is
+    boolean biasInLastLayer, // Keep as boolean
+    boolean orthogonalInit, // Keep as boolean
+    FloatRange dropout, // Changed from float to FloatRange
+    OptimizerConfig optimizer // Already a record, assumed to be the new version
+) {
+    // Defaults
+    public static final int[] DEFAULT_HIDDEN_LAYERS = ArrayUtil.EMPTY_INT_ARRAY; // Ensure ArrayUtil is accessible
+    public static final UnaryOperator<Tensor> DEFAULT_ACTIVATION = Tensor.RELU;
+    public static final UnaryOperator<Tensor> DEFAULT_OUTPUT_ACTIVATION = null;
+    public static final boolean DEFAULT_BIAS_IN_LAST_LAYER = true;
+    public static final boolean DEFAULT_ORTHOGONAL_INIT = true;
+    public static final FloatRange DEFAULT_DROPOUT = new FloatRange(0.0f, 0.0f, 0.9f, 0.0f); // Range from 0 to <1
+
+    // Compact constructor
+    public NetworkConfig {
+        Objects.requireNonNull(hiddenLayers, "hiddenLayers cannot be null");
+        Objects.requireNonNull(activation, "activation function cannot be null");
+        // outputActivation can be null
+        Objects.requireNonNull(optimizer, "optimizer cannot be null");
+        Objects.requireNonNull(dropout, "dropout cannot be null");
+        if (dropout.floatValue() < 0.0f || dropout.floatValue() >= 1.0f) { // Dropout should be [0, 1)
+            throw new IllegalArgumentException("dropout must be in [0, 1)");
+        }
+    }
+
+    // Constructor for minimal setup with a specific OptimizerConfig
+    public NetworkConfig(OptimizerConfig optimizer, int... hiddenLayers) {
+        this(hiddenLayers, DEFAULT_ACTIVATION, DEFAULT_OUTPUT_ACTIVATION,
+             DEFAULT_BIAS_IN_LAST_LAYER, DEFAULT_ORTHOGONAL_INIT, DEFAULT_DROPOUT, optimizer);
+    }
+
+    // Constructor with common defaults, creating an OptimizerConfig from a learning rate value
+    public NetworkConfig(float defaultLearningRateValue, int... hiddenLayers) {
+        this(hiddenLayers, DEFAULT_ACTIVATION, DEFAULT_OUTPUT_ACTIVATION,
+             DEFAULT_BIAS_IN_LAST_LAYER, DEFAULT_ORTHOGONAL_INIT, DEFAULT_DROPOUT,
+             OptimizerConfig.of(defaultLearningRateValue));
+    }
+
+    // Constructor with common defaults, creating an OptimizerConfig from a FloatRange learning rate
+    public NetworkConfig(FloatRange defaultLearningRateRange, int... hiddenLayers) {
+        this(hiddenLayers, DEFAULT_ACTIVATION, DEFAULT_OUTPUT_ACTIVATION,
+             DEFAULT_BIAS_IN_LAST_LAYER, DEFAULT_ORTHOGONAL_INIT, DEFAULT_DROPOUT,
+             OptimizerConfig.of(defaultLearningRateRange));
+    }
+
+    // Default constructor using all default values, including a default optimizer.
+    public NetworkConfig() {
+        this(DEFAULT_HIDDEN_LAYERS, DEFAULT_ACTIVATION, DEFAULT_OUTPUT_ACTIVATION,
+             DEFAULT_BIAS_IN_LAST_LAYER, DEFAULT_ORTHOGONAL_INIT, DEFAULT_DROPOUT,
+             new OptimizerConfig() // Uses OptimizerConfig's default constructor
+            );
+    }
+
+    // Wither methods (selected examples)
+    public NetworkConfig withHiddenLayers(int... hiddenLayers) {
+        return new NetworkConfig(hiddenLayers, activation, outputActivation, biasInLastLayer, orthogonalInit, dropout, optimizer);
+    }
+
+    public NetworkConfig withOptimizer(OptimizerConfig optimizer) {
+        return new NetworkConfig(hiddenLayers, activation, outputActivation, biasInLastLayer, orthogonalInit, dropout, optimizer);
+    }
+
+    public NetworkConfig withDropout(FloatRange dropout) {
+        return new NetworkConfig(hiddenLayers, activation, outputActivation, biasInLastLayer, orthogonalInit, dropout, optimizer);
+    }
+
+    public NetworkConfig withDropout(float dropoutValue) {
+        // Assuming FloatRange constructor (value, min, max, default)
+        return new NetworkConfig(hiddenLayers, activation, outputActivation, biasInLastLayer, orthogonalInit,
+                                 new FloatRange(dropoutValue, this.dropout.min(), this.dropout.max(), dropoutValue), optimizer);
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/OdeConfig.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/OdeConfig.java
@@ -1,0 +1,62 @@
+package jcog.tensor.rl.agents.pg.configs;
+
+import jcog.signal.IntRange; // Assuming this exists
+
+import java.util.Objects;
+
+public record OdeConfig(
+    IntRange stateSize,    // Changed from int
+    IntRange hiddenSize,   // Changed from int
+    IntRange steps,        // Changed from int
+    SolverType solverType
+) {
+    public enum SolverType {EULER, RK4}
+
+    // Defaults
+    public static final IntRange DEFAULT_STATE_SIZE = new IntRange(64, 8, 256, 64);
+    public static final IntRange DEFAULT_HIDDEN_SIZE = new IntRange(128, 16, 512, 128);
+    public static final IntRange DEFAULT_STEPS = new IntRange(5, 1, 20, 5);
+    public static final SolverType DEFAULT_SOLVER_TYPE = SolverType.RK4;
+
+    public OdeConfig {
+        Objects.requireNonNull(stateSize, "stateSize cannot be null");
+        Objects.requireNonNull(hiddenSize, "hiddenSize cannot be null");
+        Objects.requireNonNull(steps, "steps cannot be null");
+        Objects.requireNonNull(solverType, "solverType cannot be null.");
+
+        if (stateSize.intValue() <= 0) throw new IllegalArgumentException("stateSize must be positive.");
+        if (hiddenSize.intValue() <= 0) throw new IllegalArgumentException("hiddenSize must be positive.");
+        if (steps.intValue() <= 0) throw new IllegalArgumentException("steps must be positive.");
+    }
+
+    public OdeConfig() {
+        this(DEFAULT_STATE_SIZE, DEFAULT_HIDDEN_SIZE, DEFAULT_STEPS, DEFAULT_SOLVER_TYPE);
+    }
+
+    // Wither methods
+    public OdeConfig withStateSize(IntRange stateSize) {
+        return new OdeConfig(stateSize, hiddenSize, steps, solverType);
+    }
+    public OdeConfig withStateSize(int value) {
+        // Assuming IntRange constructor (value, min, max, default)
+        return new OdeConfig(new IntRange(value, this.stateSize.min(), this.stateSize.max(), value), hiddenSize, steps, solverType);
+    }
+
+    public OdeConfig withHiddenSize(IntRange hiddenSize) {
+        return new OdeConfig(stateSize, hiddenSize, steps, solverType);
+    }
+    public OdeConfig withHiddenSize(int value) {
+        return new OdeConfig(stateSize, new IntRange(value, this.hiddenSize.min(), this.hiddenSize.max(), value), steps, solverType);
+    }
+
+    public OdeConfig withSteps(IntRange steps) {
+        return new OdeConfig(stateSize, hiddenSize, steps, solverType);
+    }
+    public OdeConfig withSteps(int value) {
+        return new OdeConfig(stateSize, hiddenSize, new IntRange(value, this.steps.min(), this.steps.max(), value), solverType);
+    }
+
+    public OdeConfig withSolverType(SolverType solverType) {
+        return new OdeConfig(stateSize, hiddenSize, steps, solverType);
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/OptimizerConfig.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/OptimizerConfig.java
@@ -1,0 +1,68 @@
+package jcog.tensor.rl.agents.pg.configs;
+
+import jcog.math.FloatSupplier;
+import jcog.signal.FloatRange; // Assuming this exists
+import jcog.tensor.Optimizers;
+import jcog.tensor.Tensor;
+
+import java.util.Objects;
+
+public record OptimizerConfig(
+    Type type,
+    FloatRange learningRate // Changed from float to FloatRange
+) {
+    public enum Type {ADAM, SGD, LION, RANGER, ADAMW} // Added ADAMW, LION, RANGER as they are common
+
+    // Default values
+    public static final Type DEFAULT_OPTIMIZER_TYPE = Type.ADAM;
+    public static final FloatRange DEFAULT_LEARNING_RATE = new FloatRange(1e-3f, 1e-6f, 1e-1f, 1e-3f);
+
+    public OptimizerConfig {
+        Objects.requireNonNull(type, "Optimizer type cannot be null");
+        Objects.requireNonNull(learningRate, "Learning rate cannot be null");
+        if (learningRate.floatValue() <= 0) throw new IllegalArgumentException("Learning rate must be positive.");
+    }
+
+    // Static factory for default type if learning rate FloatRange is provided
+    public static OptimizerConfig of(FloatRange learningRate) {
+        return new OptimizerConfig(DEFAULT_OPTIMIZER_TYPE, learningRate);
+    }
+
+    // Static factory for default type if learning rate float is provided
+    public static OptimizerConfig of(float learningRateValue) {
+        // Assuming FloatRange constructor can take (value, min, max, default) or similar
+        // For now, creating a new FloatRange with potentially different min/max if not provided explicitly
+        return new OptimizerConfig(DEFAULT_OPTIMIZER_TYPE, new FloatRange(learningRateValue, DEFAULT_LEARNING_RATE.min(), DEFAULT_LEARNING_RATE.max(), learningRateValue));
+    }
+
+    // Default constructor
+    public OptimizerConfig() {
+        this(DEFAULT_OPTIMIZER_TYPE, DEFAULT_LEARNING_RATE);
+    }
+
+    // Wither methods
+    public OptimizerConfig withType(Type type) {
+        return new OptimizerConfig(type, learningRate);
+    }
+
+    public OptimizerConfig withLearningRate(FloatRange learningRate) {
+        return new OptimizerConfig(type, learningRate);
+    }
+
+    public OptimizerConfig withLearningRate(float learningRateValue) {
+        return new OptimizerConfig(type, new FloatRange(learningRateValue, this.learningRate.min(), this.learningRate.max(), learningRateValue));
+    }
+
+    public Tensor.Optimizer build() {
+        FloatSupplier lrSupplier = learningRate::floatValue; // Method reference to get the float
+        return switch (type) {
+            case ADAM -> new Optimizers.ADAM(lrSupplier).get();
+            case SGD -> new Optimizers.SGD(lrSupplier).get();
+            // Assuming LION, Ranger, AdamW constructors exist in jcog.tensor.Optimizers
+            // If not, these would cause compilation errors later.
+            case LION -> new Optimizers.LION(lrSupplier).get();
+            case RANGER -> new Optimizers.Ranger(lrSupplier).get();
+            case ADAMW -> new Optimizers.AdamW(lrSupplier).get();
+        };
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/PPOAgentConfig.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/PPOAgentConfig.java
@@ -1,0 +1,57 @@
+package jcog.tensor.rl.agents.pg.configs;
+
+import java.util.Objects;
+
+public record PPOAgentConfig(
+    HyperparamConfig hyperparams,
+    NetworkConfig policyNetworkConfig,
+    NetworkConfig valueNetworkConfig,
+    ActionConfig actionConfig,
+    MemoryConfig memoryConfig
+) {
+    public PPOAgentConfig {
+        Objects.requireNonNull(hyperparams, "hyperparams cannot be null");
+        Objects.requireNonNull(policyNetworkConfig, "policyNetworkConfig cannot be null");
+        Objects.requireNonNull(valueNetworkConfig, "valueNetworkConfig cannot be null");
+        Objects.requireNonNull(actionConfig, "actionConfig cannot be null");
+        Objects.requireNonNull(memoryConfig, "memoryConfig cannot be null");
+
+        if (memoryConfig.replayBuffer() != null) {
+            System.err.println("Warning: ReplayBufferConfig in MemoryConfig is present for PPOAgentConfig. " +
+                               "PPO typically uses on-policy batch collection via memoryConfig.episodeLength().");
+        }
+        // PPO is on-policy, requires episodeLength from MemoryConfig.
+        if (memoryConfig.episodeLength() == null || memoryConfig.episodeLength().intValue() <= 0) {
+            throw new IllegalArgumentException("MemoryConfig must define a positive episodeLength for PPO.");
+        }
+        // PPO specific hyperparameter checks from HyperparamConfig
+        if (hyperparams.ppoClip().floatValue() <= 0) {
+            throw new IllegalArgumentException("PPO clipping epsilon (ppoClip from hyperparams) must be positive.");
+        }
+        if (hyperparams.epochs().intValue() <= 0) {
+            throw new IllegalArgumentException("Number of PPO epochs (from hyperparams) must be positive.");
+        }
+        // Lambda for GAE should be in [0,1] - this is usually validated in HyperparamConfig itself.
+    }
+
+    /**
+     * Default constructor that initializes with default configurations.
+     * Learning rates for policy and value networks are taken from HyperparamConfig defaults.
+     * PPO specific parameters like clip range, epochs, lambda are also from HyperparamConfig defaults.
+     */
+    public PPOAgentConfig() {
+        this(
+            new HyperparamConfig(),
+            new NetworkConfig(
+                OptimizerConfig.of(new HyperparamConfig().policyLR().floatValue())
+            ),
+            new NetworkConfig(
+                OptimizerConfig.of(new HyperparamConfig().valueLR().floatValue())
+            ),
+            new ActionConfig(),
+            new MemoryConfig(        // PPO uses on-policy memory
+                MemoryConfig.DEFAULT_EPISODE_LENGTH.intValue()
+            )
+        );
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/ReinforceAgentConfig.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/ReinforceAgentConfig.java
@@ -1,0 +1,43 @@
+package jcog.tensor.rl.agents.pg.configs;
+
+import java.util.Objects;
+
+public record ReinforceAgentConfig(
+    HyperparamConfig hyperparams,
+    NetworkConfig policyNetworkConfig, // For the policy network
+    ActionConfig actionConfig,
+    MemoryConfig memoryConfig // For episodeLength / buffer capacity
+) {
+    public ReinforceAgentConfig {
+        Objects.requireNonNull(hyperparams, "hyperparams cannot be null");
+        Objects.requireNonNull(policyNetworkConfig, "policyNetworkConfig cannot be null");
+        Objects.requireNonNull(actionConfig, "actionConfig cannot be null");
+        Objects.requireNonNull(memoryConfig, "memoryConfig cannot be null");
+        if (memoryConfig.replayBuffer() != null) {
+            // REINFORCE is on-policy, replay buffer is not standard.
+            // Allow it but note that episodeLength from memoryConfig is primary.
+            System.err.println("Warning: ReplayBufferConfig in MemoryConfig is present for ReinforceAgentConfig. " +
+                               "REINFORCE typically uses episode-based on-policy memory via memoryConfig.episodeLength().");
+        }
+         if (memoryConfig.episodeLength() == null || memoryConfig.episodeLength().intValue() <= 0) {
+            throw new IllegalArgumentException("MemoryConfig must define a positive episodeLength for REINFORCE.");
+        }
+    }
+
+    /**
+     * Default constructor that initializes with default configurations.
+     * Policy learning rate is taken from the default HyperparamConfig.
+     */
+    public ReinforceAgentConfig() {
+        this(
+            new HyperparamConfig(), // Default hyperparameters
+            new NetworkConfig( // Default network config for policy
+                OptimizerConfig.of(new HyperparamConfig().policyLR().floatValue()) // Use default policy LR
+            ),
+            new ActionConfig(),     // Default action config
+            new MemoryConfig(       // Default memory config for on-policy
+                MemoryConfig.DEFAULT_EPISODE_LENGTH.intValue()
+            )
+        );
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/VPGAgentConfig.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/configs/VPGAgentConfig.java
@@ -1,0 +1,48 @@
+package jcog.tensor.rl.agents.pg.configs;
+
+import java.util.Objects;
+
+public record VPGAgentConfig(
+    HyperparamConfig hyperparams,
+    NetworkConfig policyNetworkConfig,
+    NetworkConfig valueNetworkConfig, // Specific config for the value network
+    ActionConfig actionConfig,
+    MemoryConfig memoryConfig
+) {
+    public VPGAgentConfig {
+        Objects.requireNonNull(hyperparams, "hyperparams cannot be null");
+        Objects.requireNonNull(policyNetworkConfig, "policyNetworkConfig cannot be null");
+        Objects.requireNonNull(valueNetworkConfig, "valueNetworkConfig cannot be null");
+        Objects.requireNonNull(actionConfig, "actionConfig cannot be null");
+        Objects.requireNonNull(memoryConfig, "memoryConfig cannot be null");
+
+        if (memoryConfig.replayBuffer() != null) {
+            // VPG is on-policy, replay buffer is not standard.
+            System.err.println("Warning: ReplayBufferConfig in MemoryConfig is present for VPGAgentConfig. " +
+                               "VPG typically uses episode-based on-policy memory via memoryConfig.episodeLength().");
+        }
+        if (memoryConfig.episodeLength() == null || memoryConfig.episodeLength().intValue() <= 0) {
+            throw new IllegalArgumentException("MemoryConfig must define a positive episodeLength for VPG.");
+        }
+    }
+
+    /**
+     * Default constructor that initializes with default configurations.
+     * Learning rates for policy and value networks are taken from HyperparamConfig defaults.
+     */
+    public VPGAgentConfig() {
+        this(
+            new HyperparamConfig(), // Default hyperparameters
+            new NetworkConfig( // Default network config for policy
+                OptimizerConfig.of(new HyperparamConfig().policyLR().floatValue()) // Uses default policy LR
+            ),
+            new NetworkConfig( // Default network config for value function
+                OptimizerConfig.of(new HyperparamConfig().valueLR().floatValue()) // Uses default value LR
+            ),
+            new ActionConfig(),     // Default action config
+            new MemoryConfig(       // Default memory config for on-policy
+                MemoryConfig.DEFAULT_EPISODE_LENGTH.intValue()
+            )
+        );
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/memory/AgentMemory.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/memory/AgentMemory.java
@@ -1,0 +1,51 @@
+package jcog.tensor.rl.agents.pg.memory;
+
+import jcog.tensor.rl.pg.util.Experience2; // Still using existing Experience2
+
+import java.util.List;
+
+/**
+ * Interface for memory buffers used by RL agents.
+ */
+public interface AgentMemory {
+
+    /**
+     * Adds a new experience to the memory.
+     * @param experience The experience to add.
+     */
+    void add(Experience2 experience);
+
+    /**
+     * Samples a batch of experiences from the memory.
+     * The definition of a "batch" can vary:
+     * - For on-policy, it might return all experiences since the last clear.
+     * - For off-policy, it might return a random minibatch.
+     * @param batchSize The desired size of the batch (may be ignored by some implementations, e.g., on-policy).
+     * @return A list of experiences.
+     */
+    List<Experience2> sample(int batchSize);
+
+    /**
+     * Returns all experiences currently in the buffer.
+     * Useful for on-policy algorithms that process the entire episode/batch.
+     * @return A list of all experiences.
+     */
+    List<Experience2> getAll();
+
+    /**
+     * Clears all experiences from the memory.
+     */
+    void clear();
+
+    /**
+     * Returns the current number of experiences stored in the memory.
+     * @return The size of the memory.
+     */
+    int size();
+
+    /**
+     * Returns the capacity of the memory buffer.
+     * @return The maximum number of experiences the buffer can hold.
+     */
+    int capacity();
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/memory/OnPolicyBuffer.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/memory/OnPolicyBuffer.java
@@ -1,0 +1,62 @@
+package jcog.tensor.rl.agents.pg.memory;
+
+import jcog.data.list.Lst; // Assuming Lst is accessible, as used in PGBuilder's version
+import jcog.tensor.rl.pg.util.Experience2; // Still using existing Experience2
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class OnPolicyBuffer implements AgentMemory {
+
+    public final int capacity; // Made public final for GUI access/inspection
+    private final List<Experience2> buffer;
+
+    public OnPolicyBuffer(int capacity) {
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("Capacity must be positive.");
+        }
+        this.capacity = capacity;
+        // PGBuilder's OnPolicyEpisodeBuffer used Lst. Assuming it's a custom list type.
+        // If Lst is not available or appropriate, java.util.ArrayList could be used.
+        this.buffer = new Lst<>(capacity);
+    }
+
+    @Override
+    public void add(Experience2 experience) {
+        Objects.requireNonNull(experience, "Experience cannot be null.");
+        if (buffer.size() < this.capacity) {
+            buffer.add(experience);
+        }
+        // If buffer is full, new experiences are not added.
+        // The agent is expected to process and clear the buffer.
+    }
+
+    @Override
+    public List<Experience2> sample(int batchSize) {
+        // For this on-policy buffer, sample(batchSize) returns all current experiences,
+        // ignoring batchSize, as is typical for on-policy learning phases.
+        return getAll();
+    }
+
+    @Override
+    public List<Experience2> getAll() {
+        // Return a defensive copy to prevent external modification of the internal buffer.
+        return new ArrayList<>(buffer);
+    }
+
+    @Override
+    public void clear() {
+        buffer.clear();
+    }
+
+    @Override
+    public int size() {
+        return buffer.size();
+    }
+
+    @Override
+    public int capacity() {
+        return this.capacity;
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/networks/GaussianPolicyNet.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/networks/GaussianPolicyNet.java
@@ -1,0 +1,91 @@
+package jcog.tensor.rl.agents.pg.networks;
+
+import jcog.tensor.Models;
+import jcog.tensor.Models.Linear;
+import jcog.tensor.Tensor;
+import jcog.tensor.rl.agents.pg.configs.NetworkConfig; // Use new config
+// Uses GaussianDistribution from the new util package
+import jcog.tensor.rl.agents.pg.util.AgentUtils;
+
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+
+public class GaussianPolicyNet extends Models.Layers {
+    public final NetworkConfig config;
+    public final int inputs;
+    public final int outputs;
+    public final Models.Layers body;
+    public final Linear muHead;
+    public final Linear logSigmaHead;
+
+    private static int getLastLayerSize(NetworkConfig config, int inputs) {
+        if (config.hiddenLayers() == null || config.hiddenLayers().length == 0) {
+            return inputs;
+        }
+        return config.hiddenLayers()[config.hiddenLayers().length - 1];
+    }
+
+    private static Linear createOrthogonalLinear(int I, int O, UnaryOperator<Tensor> activation, boolean bias, double gain) {
+        var linearLayer = new Linear(I, O, activation, bias);
+        Tensor.orthoInit(linearLayer.weight, gain);
+        if (bias && linearLayer.bias != null) {
+            linearLayer.bias.zero();
+        }
+        return linearLayer;
+    }
+
+    private static Models.Layers buildDefaultMlpBody(NetworkConfig config, int inputs) {
+        Models.Layers newBody = new Models.Layers(config.activation(), config.activation(), true);
+        int lastLayerSize = inputs;
+        if (config.hiddenLayers() != null) {
+            for (int hiddenSize : config.hiddenLayers()) {
+                newBody.layer.add(createOrthogonalLinear(lastLayerSize, hiddenSize, config.activation(), true, Math.sqrt(2.0)));
+                lastLayerSize = hiddenSize;
+            }
+        }
+        return newBody;
+    }
+
+    public GaussianPolicyNet(NetworkConfig config, int inputs, int outputs) {
+        this(config, inputs, outputs,
+             buildDefaultMlpBody(config, inputs),
+             createOrthogonalLinear(getLastLayerSize(config, inputs), outputs, null, config.biasInLastLayer(), 0.01),
+             createOrthogonalLinear(getLastLayerSize(config, inputs), outputs, null, config.biasInLastLayer(), 0.01)
+        );
+    }
+
+    public GaussianPolicyNet(NetworkConfig config, int inputs, int outputs, Models.Layers body, Linear muHead, Linear logSigmaHead) {
+        super(null, null, false);
+        this.config = Objects.requireNonNull(config, "NetworkConfig cannot be null");
+        this.inputs = inputs;
+        this.outputs = outputs;
+        this.body = Objects.requireNonNull(body, "Body cannot be null");
+        this.muHead = Objects.requireNonNull(muHead, "muHead cannot be null");
+        this.logSigmaHead = Objects.requireNonNull(logSigmaHead, "logSigmaHead cannot be null");
+
+        this.layer.add(this.body);
+        this.layer.add(this.muHead);
+        this.layer.add(this.logSigmaHead);
+    }
+
+    public AgentUtils.GaussianDistribution getDistribution(Tensor state, float sigmaMin, float sigmaMax) {
+        var bodyOutput = this.body.apply(state);
+        var mu = this.muHead.apply(bodyOutput);
+        var sigma = this.logSigmaHead.apply(bodyOutput).exp().clip(sigmaMin, sigmaMax);
+        // sigmaMin and sigmaMax are floats passed in. These would typically come from ActionConfig's FloatRange.floatValue().
+        return new AgentUtils.GaussianDistribution(mu, sigma);
+    }
+
+    @Override
+    public Tensor apply(Tensor t) {
+        // Defaulting to returning mu. getDistribution() is preferred for policy evaluation.
+        var bodyOutput = this.body.apply(t);
+        return this.muHead.apply(bodyOutput);
+    }
+
+    @Override
+    public void train(boolean training) {
+        super.train(training);
+        // body, muHead, logSigmaHead are added to this.layer, so super.train() handles them.
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/networks/ValueNet.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/networks/ValueNet.java
@@ -1,0 +1,55 @@
+package jcog.tensor.rl.agents.pg.networks;
+
+import jcog.tensor.Models;
+import jcog.tensor.Tensor;
+import jcog.tensor.rl.agents.pg.configs.NetworkConfig; // Use new config
+import jcog.tensor.rl.util.RLNetworkUtils; // For createMlp
+
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+
+// Renamed to ValueNet
+public class ValueNet extends Models.Layers {
+    public final NetworkConfig config;
+    public final int stateDim;
+    public final UnaryOperator<Tensor> network; // The actual MLP
+
+    public ValueNet(NetworkConfig config, int stateDim) {
+        super(null, null, false);
+        this.config = Objects.requireNonNull(config, "NetworkConfig cannot be null");
+        this.stateDim = stateDim;
+
+        this.network = RLNetworkUtils.createMlp(stateDim, 1, config); // Output dimension is 1 for value
+
+        // Add the created network to this.layer so its parameters are discoverable
+        // and train() mode propagates. This assumes RLNetworkUtils.createMlp returns
+        // an instance that can be added to Models.Layers's internal list,
+        // ideally an instance of Models.Model or Models.Layers itself.
+        if (this.network instanceof Models.Model) { // Models.Model is parent of Models.Layers
+            this.layer.add((Models.Model) this.network);
+        } else {
+            // This case might indicate that parameters of 'network' are not automatically found by Tensor.parameters(thisValueNetInstance)
+            // or that train() mode is not propagated correctly.
+            // For a simple UnaryOperator<Tensor> that is not a Models.Model, special handling for parameters and train mode might be needed.
+            // However, createMlp is expected to return a proper network structure.
+            System.err.println("Warning: ValueNet's MLP (" + this.network.getClass().getName() + ") from RLNetworkUtils.createMlp might not be fully integrated for parameter discovery or train mode propagation if not a jcog.tensor.Models.Model instance and added to the internal layer list.");
+        }
+    }
+
+    @Override
+    public Tensor apply(Tensor state) {
+        return this.network.apply(state);
+    }
+
+    @Override
+    public void train(boolean training) {
+        super.train(training); // Propagates to models/layers added to this.layer
+        // If `network` is a Models.Layers (or Model) and was added to `this.layer`,
+        // super.train(training) handles it.
+        // If `network` has its own train method and wasn't added (or isn't a Model), it might need explicit call:
+        // if (this.network instanceof Models.Layers) { // Defensive check
+        //    ((Models.Layers) this.network).train(training);
+        // }
+        // However, the expectation is that adding to this.layer is sufficient if it's a Model.
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/util/AgentUtils.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/agents/pg/util/AgentUtils.java
@@ -1,0 +1,118 @@
+package jcog.tensor.rl.agents.pg.util; // New package
+
+import jcog.Util; // Assuming jcog.Util is accessible
+import jcog.tensor.Models; // For parameter iteration
+import jcog.tensor.Tensor;
+
+import java.util.function.UnaryOperator;
+
+public enum AgentUtils { // Using enum for utility class style
+    ; // No instances
+
+    public static final double EPSILON = 1e-8; // Epsilon for numerical stability
+
+    /**
+     * Normalizes an array of doubles to have zero mean and unit variance.
+     * Modifies the array in-place.
+     * @param x The array to normalize.
+     */
+    public static void normalize(double[] x) {
+        if (x == null || x.length == 0) {
+            return;
+        }
+        var meanVar = Util.variance(x); // Assumes Util.variance returns [mean, variance]
+        double mean = meanVar[0];
+        double stddev = Math.sqrt(meanVar[1]);
+        // Handle cases where stddev is zero or very close to zero
+        if (stddev < EPSILON) {
+            // If stddev is effectively zero, array elements are likely all the same.
+            // Normalizing would lead to NaNs or Infs.
+            // Set all elements to 0 in this case, or leave as is if that's preferred.
+            // For advantages, setting to 0 if all are same (so stddev is 0) is common.
+            for (int i = 0; i < x.length; i++) {
+                x[i] = 0.0;
+            }
+            return;
+        }
+        for (var i = 0; i < x.length; i++) {
+            x[i] = (x[i] - mean) / stddev; // No need to add EPSILON here if stddev check is done
+        }
+    }
+
+    /**
+     * Performs a soft update of target network parameters from source network parameters.
+     * target_params = (1 - tau) * target_params + tau * source_params
+     *
+     * @param source The source network (UnaryOperator<Tensor> representing the model).
+     * @param target The target network (UnaryOperator<Tensor> representing the model).
+     * @param tau The interpolation parameter (typically a small value like 0.005).
+     */
+    public static void softUpdate(UnaryOperator<Tensor> source, UnaryOperator<Tensor> target, float tau) {
+        if (source == null || target == null) {
+            System.err.println("Warning: softUpdate called with null source or target network.");
+            return;
+        }
+        var sourceParams = Tensor.parameters(source).toList();
+        var targetParams = Tensor.parameters(target).toList();
+
+        if (sourceParams.isEmpty() && targetParams.isEmpty()) {
+            return;
+        }
+        if (sourceParams.size() != targetParams.size()) {
+            throw new IllegalArgumentException("Source and target networks have a different number of parameters for soft update: " +
+                                               sourceParams.size() + " vs " + targetParams.size());
+        }
+
+        for (var i = 0; i < sourceParams.size(); i++) {
+            var sParam = sourceParams.get(i);
+            var tParam = targetParams.get(i);
+            tParam.setData(tParam.mul(1.0f - tau).add(sParam.mul(tau)));
+        }
+    }
+
+    /**
+     * Performs a hard update (tau=1.0) of target network parameters from source network parameters.
+     * Essentially copies source parameters to target parameters.
+     *
+     * @param source The source network.
+     * @param target The target network.
+     */
+    public static void hardUpdate(UnaryOperator<Tensor> source, UnaryOperator<Tensor> target) {
+        softUpdate(source, target, 1.0f);
+    }
+
+    public record GaussianDistribution(Tensor mu, Tensor sigma) {
+        public Tensor sample(boolean deterministic) {
+            return deterministic ? mu : rsample();
+        }
+
+        public Tensor rsample() {
+            return mu.add(sigma.mul(Tensor.randGaussian(sigma.rows(), sigma.cols())));
+        }
+
+        public Tensor logProb(Tensor action) {
+            var variance = sigma.sqr().add((float) AgentUtils.EPSILON);
+            var diffSq = action.sub(mu).sqr();
+            var term1 = diffSq.div(variance);
+            var term2 = variance.log().add(Math.log(2 * Math.PI));
+            var logProbPerDim = term1.add(term2).mul(-0.5f);
+
+            if (logProbPerDim.cols() > 1 && logProbPerDim.rows() > 0) { // Ensure not scalar and has columns to sum
+                return logProbPerDim.sum(1);
+            } else {
+                return logProbPerDim;
+            }
+        }
+
+        public Tensor entropy() {
+            var logSigma = sigma.add((float)AgentUtils.EPSILON).log();
+            var entropyPerDim = logSigma.add(0.5 * (1.0 + Math.log(2 * Math.PI)));
+
+            if (entropyPerDim.cols() > 1 && entropyPerDim.rows() > 0) { // Ensure not scalar and has columns to sum
+                return entropyPerDim.sum(1);
+            } else {
+                return entropyPerDim;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Created new package structure under `jcog.tensor.rl.agents.pg`.
- Implemented REINFORCE, VPG, and PPO agents with a modular design.
- Used constructor injection for all dependencies.
- Exposed key components and configurations as `public final` fields for GUI accessibility.
- Adapted configuration records to use `FloatRange` and `IntRange` for better GUI interaction and parameter semantics.
- Defined clear interfaces and base classes for agents.
- Refactored network models (GaussianPolicyNet, ValueNet) and utility components.
- Ensured alignment with standard algorithmic formulations.