### PR TITLE
Integrate pg3 agents and update factory methods

### DIFF
--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg3/DDPGAgent.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg3/DDPGAgent.java
@@ -1,0 +1,191 @@
+package jcog.tensor.rl.pg3;
+
+import jcog.Util;
+import jcog.random.XoRoShiRo128PlusRandom;
+import jcog.tensor.Tensor;
+import jcog.tensor.rl.pg.util.Experience2;
+import jcog.tensor.rl.pg3.configs.DDPGAgentConfig;
+import jcog.tensor.rl.pg3.memory.ReplayBuffer;
+import jcog.tensor.rl.pg3.networks.CriticNet;
+import jcog.tensor.rl.pg3.networks.DeterministicPolicyNet;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+
+public class DDPGAgentImpl extends BasePolicyGradientAgent {
+
+    public final DDPGAgentConfig config;
+
+    public final DeterministicPolicyNet actor;
+    public final CriticNet critic;
+    public final DeterministicPolicyNet targetActor;
+    public final CriticNet targetCritic;
+
+    public final Tensor.Optimizer actorOptimizer;
+    public final Tensor.Optimizer criticOptimizer;
+
+    public final ReplayBuffer memory;
+    private final Random randomForNoise; // For action noise
+
+    private final Tensor.GradQueue actorGradQueue;
+    private final Tensor.GradQueue criticGradQueue;
+
+    public DDPGAgentImpl(DDPGAgentConfig config, int stateDim, int actionDim) {
+        super(stateDim, actionDim);
+        Objects.requireNonNull(config, "Agent configuration cannot be null");
+        this.config = config;
+
+        // Initialize networks
+        this.actor = new DeterministicPolicyNet(config.actorNetworkConfig(), stateDim, actionDim);
+        this.critic = new CriticNet(config.criticNetworkConfig(), stateDim, actionDim);
+        this.targetActor = new DeterministicPolicyNet(config.actorNetworkConfig(), stateDim, actionDim);
+        this.targetCritic = new CriticNet(config.criticNetworkConfig(), stateDim, actionDim);
+
+        // Initialize optimizers
+        this.actorOptimizer = config.actorOptimizerConfig().build(this.actor.getWeights());
+        this.criticOptimizer = config.criticOptimizerConfig().build(this.critic.getWeights());
+
+        // Initialize memory
+        if (config.memoryConfig().replayBufferConfig() == null) {
+            throw new IllegalArgumentException("DDPG requires ReplayBufferConfig in MemoryConfig");
+        }
+        this.memory = new ReplayBuffer(config.memoryConfig().replayBufferConfig().capacity());
+
+        this.randomForNoise = new XoRoShiRo128PlusRandom(); // Or make injectable
+
+        // Copy initial weights to target networks
+        Util.softUpdate(this.targetActor.getWeights(), this.actor.getWeights(), 1.0f); // Hard copy
+        Util.softUpdate(this.targetCritic.getWeights(), this.critic.getWeights(), 1.0f); // Hard copy
+
+        this.actorGradQueue = new Tensor.GradQueue(this.actor.getWeights());
+        this.criticGradQueue = new Tensor.GradQueue(this.critic.getWeights());
+
+        setTrainingMode(true); // Initialize training mode by default
+    }
+
+    @Override
+    public double[] selectAction(Tensor state, boolean deterministic) {
+        Tensor actionTensor;
+        try (var noGrad = Tensor.noGrad()) { // Action selection should not compute gradients
+            actionTensor = this.actor.apply(state);
+        }
+
+        double[] action = actionTensor.array(); // Assumes actionTensor is (1, actionDim)
+
+        if (!deterministic && this.trainingMode) {
+            // Add noise for exploration if in training mode and not requesting deterministic action
+            float noiseStddev = config.ddpgHyperparams().actionNoiseStddev();
+            if (noiseStddev > 0) {
+                for (int i = 0; i < action.length; i++) {
+                    action[i] += randomForNoise.nextGaussian() * noiseStddev;
+                }
+            }
+        }
+        // Clip action to be within valid range (e.g., if actor output is tanh, it's already [-1,1])
+        Util.clampSafe(action, -1.0, 1.0); // Assuming actions are normalized to [-1, 1]
+        return action;
+    }
+
+    @Override
+    protected ActionWithLogProb selectActionWithLogProb(Tensor state, boolean deterministic) {
+        // DDPG is deterministic and doesn't use log probabilities for its experience tuples
+        // in the same way stochastic policy agents do for entropy or importance sampling.
+        double[] actionArray = selectAction(state, deterministic);
+        return new ActionWithLogProb(actionArray, null); // LogProb is null
+    }
+
+
+    @Override
+    public void recordExperience(Experience2 experience) {
+        Objects.requireNonNull(experience, "Experience cannot be null");
+        this.memory.add(experience);
+
+        if (this.trainingMode && this.memory.size() >= config.memoryConfig().replayBufferConfig().batchSize()) {
+            // Update can be called here if memory has enough samples.
+            // For DDPG, often updates are triggered after a certain number of steps or when enough data.
+            // update(0); // Call if updating on every valid recordExperience
+        }
+    }
+
+    @Override
+    public void update(long totalSteps) {
+        if (!this.trainingMode || this.memory.size() < config.memoryConfig().replayBufferConfig().batchSize()) {
+            return;
+        }
+
+        List<Experience2> batch = this.memory.sample(config.memoryConfig().replayBufferConfig().batchSize());
+        if (batch.isEmpty()) {
+            return;
+        }
+
+        ReplayBuffer.BatchTuple tensors = ReplayBuffer.experiencesToBatchTuple(batch);
+        Tensor states = tensors.states();
+        Tensor actions = tensors.actions();
+        Tensor rewards = tensors.rewards();
+        Tensor nextStates = tensors.nextStates();
+        Tensor dones = tensors.dones(); // 1.0 if done, 0.0 if not
+
+        // --- Update Critic ---
+        Tensor targetActions;
+        try (var noGrad = Tensor.noGrad()) {
+            targetActions = this.targetActor.apply(nextStates);
+            Tensor targetQValues = this.targetCritic.apply(new Tensor[]{nextStates, targetActions});
+            Tensor y_i = rewards.add(
+                dones.mul(-1).add(1) // (1 - dones)
+                    .mul(config.hyperparams().gamma())
+                    .mul(targetQValues)
+            );
+
+            criticGradQueue.clear();
+            Tensor currentQValues = this.critic.apply(new Tensor[]{states, actions});
+            Tensor criticLoss = currentQValues.loss(y_i.detach(), Tensor.Loss.MeanSquared);
+            criticLoss.minimize(criticGradQueue);
+        }
+        criticGradQueue.optimize(criticOptimizer);
+
+        // --- Update Actor ---
+        if (getUpdateCount() % config.ddpgHyperparams().policyUpdateFreq() == 0) {
+            actorGradQueue.clear();
+            Tensor newActionsFromActor = this.actor.apply(states);
+            Tensor actorLoss = this.critic.apply(new Tensor[]{states, newActionsFromActor}).mean().neg();
+            actorLoss.minimize(actorGradQueue);
+            actorGradQueue.optimize(actorOptimizer);
+
+            Util.softUpdate(this.targetActor.getWeights(), this.actor.getWeights(), config.ddpgHyperparams().tau());
+            Util.softUpdate(this.targetCritic.getWeights(), this.critic.getWeights(), config.ddpgHyperparams().tau());
+        }
+
+        incrementUpdateCount();
+    }
+
+
+    @Override
+    public Object getPolicy() {
+        return this.actor;
+    }
+
+    @Override
+    public Object getValueFunction() {
+        return this.critic;
+    }
+
+    @Override
+    public Object getConfig() {
+        return this.config;
+    }
+
+    @Override
+    public void setTrainingMode(boolean training) {
+        super.setTrainingMode(training);
+        this.actor.train(training);
+        this.critic.train(training);
+        this.targetActor.train(false);
+        this.targetCritic.train(false);
+    }
+
+    @Override
+    public void clearMemory() {
+        this.memory.clear();
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg3/PPOAgent.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg3/PPOAgent.java
@@ -52,9 +52,10 @@ public class PPOAgent extends BasePolicyGradientAgent {
         return result.action();
     }
 
-    public record ActionWithLogProb(double[] action, Tensor logProb) {}
+    // public record ActionWithLogProb(double[] action, Tensor logProb) {} // Now in BasePolicyGradientAgent
 
-    public ActionWithLogProb selectActionWithLogProb(Tensor state, boolean deterministic) {
+    @Override
+    protected ActionWithLogProb selectActionWithLogProb(Tensor state, boolean deterministic) {
         try (var noGrad = Tensor.noGrad()) {
             AgentUtils.GaussianDistribution dist = policy.getDistribution(
                 state,

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg3/ReinforceAgent.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg3/ReinforceAgent.java
@@ -163,4 +163,12 @@ public class ReinforceAgent extends BasePolicyGradientAgent {
     public void clearMemory() {
         this.memory.clear();
     }
+
+    @Override
+    protected ActionWithLogProb selectActionWithLogProb(Tensor state, boolean deterministic) {
+        // Reinforce calculates logProbs during its update based on the episode's actions.
+        // The selectAction method is sufficient here, and logProb can be null for the base class's caching.
+        double[] action = selectAction(state, deterministic);
+        return new ActionWithLogProb(action, null);
+    }
 }

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg3/ReinforceDNCAgent.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg3/ReinforceDNCAgent.java
@@ -1,0 +1,66 @@
+package jcog.tensor.rl.pg3;
+
+import jcog.tensor.Tensor;
+import jcog.tensor.model.DNCMemory; // Assuming this is the DNC model path
+import jcog.tensor.rl.pg3.configs.ReinforceAgentConfig; // or a new DNC specific config
+import jcog.tensor.rl.pg3.networks.GaussianPolicyNet; // May need a custom policy net
+
+import java.util.function.UnaryOperator;
+
+// Config might need to be more specific if DNC params are complex
+// For now, let's assume ReinforceAgentConfig can be made to work or a
+// wrapper config is used by the factory.
+public class ReinforceDNCAgent extends ReinforceAgent {
+
+    protected UnaryOperator<Tensor> dncPolicyModel; // The actual DNC based model
+
+    // Constructor will need to set up the DNC model and potentially
+    // override or replace the 'policy' field from ReinforceAgent.
+    public ReinforceDNCAgent(ReinforceAgentConfig config, int stateDim, int actionDim,
+                             int dncMemorySize, int dncMemoryWords, int dncReadHeads, DNCMemory.EraseMode eraseMode) {
+        super(config, stateDim, actionDim); // Calls parent constructor
+
+        // 1. Construct the DNC layers + output layers for mu and sigma (total actionDim * 2)
+        // This is where the DNC model from the old pg.ReinforceDNC would be built.
+        // For example:
+        // DNCMemory dnc = new DNCMemory(stateDim, config.policyNetworkConfig().hiddenLayerSizes()[0], dncMemorySize, dncMemoryWords, dncReadHeads, eraseMode);
+        // UnaryOperator<Tensor> outputLayer = new Models.Linear(config.policyNetworkConfig().hiddenLayerSizes()[0], actionDim * 2, true);
+        // this.dncPolicyModel = dnc.andThen(outputLayer);
+
+        // Placeholder for DNC model construction logic - this needs to be detailed
+        // based on old pg.ReinforceDNC and how it integrates.
+        // The key challenge is that super.policy is already a GaussianPolicyNet.
+        // We need to replace its internal network or replace the policy object itself.
+
+        // Hacky: For now, let's assume we can create a new GaussianPolicyNet here
+        // where its *internal* network is our DNC model. This requires GaussianPolicyNet to be flexible.
+        // This is a conceptual sketch of how it *could* work if GaussianPolicyNet was adapted.
+        // final UnaryOperator<Tensor> actualDNCNetwork = setupDNCNetwork(stateDim, actionDim, config, dncMemorySize, dncMemoryWords, dncReadHeads, eraseMode);
+        // this.policy = new GaussianPolicyNet(config.policyNetworkConfig(), stateDim, actionDim, actualDNCNetwork);
+        // This direct replacement of `this.policy` would also require policyOptimizer to be re-initialized for the new policy parameters.
+
+        // TODO: This requires a more detailed thought on how to properly inject/override the policy network
+        // within the pg3 framework. For now, this class is a placeholder.
+        // The factory method in Agents.java will call this constructor.
+        System.err.println("ReinforceDNCAgent: DNC model construction and integration with GaussianPolicyNet needs proper implementation.");
+
+    }
+
+    // Placeholder for actual DNC network setup
+    private UnaryOperator<Tensor> setupDNCNetwork(int stateDim, int actionDim, ReinforceAgentConfig config,
+                                                  int dncMemorySize, int dncMemoryWords, int dncReadHeads, DNCMemory.EraseMode eraseMode) {
+        // This would replicate the network structure from the old pg.ReinforceDNC
+        // using DNCMemory and appropriate linear layers for mu/sigma.
+        // Example:
+        // int hiddenSize = config.policyNetworkConfig().hiddenLayerSizes()[0]; // Assuming first hidden is DNC output into linear
+        // DNCMemory dnc = new DNCMemory(stateDim, hiddenSize, dncMemorySize, dncMemoryWords, dncReadHeads, eraseMode, null, null);
+        // UnaryOperator<Tensor> outputLayer = new Models.Linear(hiddenSize, actionDim * 2, true); // For mu and sigma
+        // return dnc.andThen(Tensor.RELU).andThen(outputLayer); // Example activation after DNC
+        throw new UnsupportedOperationException("DNC Network setup not fully implemented");
+    }
+
+    // If the DNC model affects how actions are selected or log probs calculated,
+    // selectAction and/or selectActionWithLogProb might need to be overridden.
+    // If the loss calculation is different, update() might need overrides.
+    // For now, inheriting from ReinforceAgent.
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg3/ReinforceODEAgent.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg3/ReinforceODEAgent.java
@@ -1,0 +1,49 @@
+package jcog.tensor.rl.pg3;
+
+import jcog.tensor.Tensor;
+import jcog.tensor.model.ODELayer; // Assuming this is the ODELayer path
+import jcog.tensor.rl.pg3.configs.ReinforceAgentConfig;
+
+import java.util.function.UnaryOperator;
+
+// Similar to ReinforceDNCAgent, this agent will extend ReinforceAgent
+// and aim to use an ODELayer within its policy network.
+public class ReinforceODEAgent extends ReinforceAgent {
+
+    protected UnaryOperator<Tensor> odePolicyModel;
+
+    // Constructor for the Neural ODE variant
+    public ReinforceODEAgent(ReinforceAgentConfig config, int stateDim, int actionDim,
+                             int odeHiddenSize, int odeSolverSteps) {
+        super(config, stateDim, actionDim);
+
+        // TODO: Implement the construction of a policy network that incorporates an ODELayer.
+        // This will be conceptually similar to ReinforceDNCAgent:
+        // 1. Construct the ODELayer.
+        // 2. Construct output layers to produce mu and sigma (actionDim * 2) from ODELayer's output.
+        // 3. Integrate this custom model with the GaussianPolicyNet used by ReinforceAgent,
+        //    likely requiring GaussianPolicyNet to be flexible or by replacing `this.policy`.
+
+        System.err.println("ReinforceODEAgent: ODE model construction and integration needs proper implementation.");
+    }
+
+    // Constructor for the Liquid Time Constant (LTC) variant (if to be supported by this class)
+    // public ReinforceODEAgent(ReinforceAgentConfig config, int stateDim, int actionDim,
+    //                          int ltcNeurons, int ltcSolverSteps) {
+    //     super(config, stateDim, actionDim);
+    //     System.err.println("ReinforceODEAgent (LTC): LTC model construction needs implementation.");
+    // }
+
+
+    // Placeholder for actual ODE network setup
+    private UnaryOperator<Tensor> setupODENetwork(int stateDim, int actionDim, ReinforceAgentConfig config,
+                                                  int odeHiddenSize, int odeSolverSteps) {
+        // This would replicate the network structure from the old pg.ReinforceODE (NeuralODE variant)
+        // using ODELayer.
+        // Example:
+        // ODELayer odeLayer = new ODELayer(stateDim, odeHiddenSize, odeHiddenSize, true, () -> odeSolverSteps);
+        // UnaryOperator<Tensor> outputLayer = new Models.Linear(odeHiddenSize, actionDim * 2, true); // For mu and sigma
+        // return odeLayer.andThen(Tensor.RELU).andThen(outputLayer);
+        throw new UnsupportedOperationException("ODE Network setup not fully implemented");
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg3/SACAgent.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg3/SACAgent.java
@@ -1,0 +1,328 @@
+package jcog.tensor.rl.pg3;
+
+import jcog.Util;
+import jcog.tensor.Tensor;
+import jcog.tensor.rl.pg.util.Experience2;
+import jcog.tensor.rl.pg3.configs.SACAgentConfig;
+import jcog.tensor.rl.pg3.memory.ReplayBuffer;
+import jcog.tensor.rl.pg3.networks.CriticNet;
+import jcog.tensor.rl.pg3.networks.GaussianPolicyNet;
+import jcog.tensor.rl.pg3.util.AgentUtils;
+
+import java.util.List;
+import java.util.Objects;
+
+public class SACAgent extends BasePolicyGradientAgent {
+
+    public final SACAgentConfig config;
+
+    public final GaussianPolicyNet policy; // Actor
+    public final CriticNet qNet1;          // Critic 1
+    public final CriticNet qNet2;          // Critic 2
+    public final CriticNet targetQNet1;    // Target Critic 1
+    public final CriticNet targetQNet2;    // Target Critic 2
+
+    public final Tensor.Optimizer policyOptimizer;
+    public final Tensor.Optimizer q1Optimizer;
+    public final Tensor.Optimizer q2Optimizer;
+    public final Tensor.Optimizer alphaOptimizer; // For temperature auto-tuning
+
+    public final ReplayBuffer memory;
+
+    private final Tensor logAlpha; // Learnable temperature parameter
+    private final float targetEntropy;
+
+    private final Tensor.GradQueue policyGradQueue;
+    private final Tensor.GradQueue q1GradQueue;
+    private final Tensor.GradQueue q2GradQueue;
+    private final Tensor.GradQueue alphaGradQueue;
+    private final int actionDim;
+
+    public SACAgent(SACAgentConfig config, int stateDim, int actionDim) {
+        super(stateDim, actionDim);
+        Objects.requireNonNull(config, "Agent configuration cannot be null");
+        this.config = config;
+        this.actionDim = actionDim;
+
+        // Initialize networks
+        this.policy = new GaussianPolicyNet(config.policyNetworkConfig(), stateDim, actionDim);
+        this.qNet1 = new CriticNet(config.qNetworkConfig(), stateDim, actionDim);
+        this.qNet2 = new CriticNet(config.qNetworkConfig(), stateDim, actionDim);
+        this.targetQNet1 = new CriticNet(config.qNetworkConfig(), stateDim, actionDim);
+        this.targetQNet2 = new CriticNet(config.qNetworkConfig(), stateDim, actionDim);
+
+        // Initialize optimizers
+        this.policyOptimizer = config.policyOptimizerConfig().build(this.policy.getWeights());
+        this.q1Optimizer = config.qOptimizerConfig().build(this.qNet1.getWeights());
+        this.q2Optimizer = config.qOptimizerConfig().build(this.qNet2.getWeights());
+
+
+        // Temperature (alpha)
+        if (config.sacHyperparams().useFixedAlpha()) {
+            this.logAlpha = Tensor.scalar(Math.log(config.sacHyperparams().initialAlpha())).constant();
+            this.alphaOptimizer = null; // No optimizer needed for fixed alpha
+            this.alphaGradQueue = null;
+        } else {
+            this.logAlpha = Tensor.scalar(Math.log(config.sacHyperparams().initialAlpha())).requiresGrad();
+            this.alphaOptimizer = config.alphaOptimizerConfig().build(List.of(this.logAlpha));
+            this.alphaGradQueue = new Tensor.GradQueue(List.of(this.logAlpha));
+        }
+
+        this.targetEntropy = config.sacHyperparams().targetEntropy() != null ?
+            config.sacHyperparams().targetEntropy() :
+            (float) -actionDim; // Default target entropy: -dim(A)
+
+        // Initialize memory
+        if (config.memoryConfig().replayBufferConfig() == null) {
+            throw new IllegalArgumentException("SAC requires ReplayBufferConfig in MemoryConfig");
+        }
+        this.memory = new ReplayBuffer(config.memoryConfig().replayBufferConfig().capacity());
+
+        // Copy initial weights to target networks
+        Util.softUpdate(this.targetQNet1.getWeights(), this.qNet1.getWeights(), 1.0f); // Hard copy
+        Util.softUpdate(this.targetQNet2.getWeights(), this.qNet2.getWeights(), 1.0f); // Hard copy
+
+        this.policyGradQueue = new Tensor.GradQueue(this.policy.getWeights());
+        this.q1GradQueue = new Tensor.GradQueue(this.qNet1.getWeights());
+        this.q2GradQueue = new Tensor.GradQueue(this.qNet2.getWeights());
+
+
+        setTrainingMode(true);
+    }
+
+    /**
+     * Selects an action based on the current policy.
+     * For SAC, actions are sampled from a Gaussian distribution and then squashed by a tanh function.
+     * The log probability also needs to account for this squashing.
+     *
+     * @param state The current state.
+     * @param deterministic If true, use the mean of the policy distribution (for evaluation).
+     *                      If false, sample from the distribution (for training).
+     * @return double array representing the action.
+     */
+    @Override
+    public double[] selectAction(Tensor state, boolean deterministic) {
+        try (var noGrad = Tensor.noGrad()) {
+            AgentUtils.GaussianDistribution dist = this.policy.getDistribution(
+                state,
+                config.policyNetworkConfig().sigmaMin(), // Use sigmaMin from policy config
+                config.policyNetworkConfig().sigmaMax()  // Use sigmaMax from policy config
+            );
+            Tensor rawAction = dist.sample(deterministic);
+            Tensor squashedAction = rawAction.tanh(); // Squash action to [-1, 1]
+            return squashedAction.array(); // Assumes (1, actionDim)
+        }
+    }
+
+    /**
+     * Samples an action and also returns its log probability, accounting for the tanh squashing.
+     * This is needed for the policy update.
+     * log_prob(squashed_action) = log_prob(raw_action) - sum(log(1 - tanh(raw_action)^2 + epsilon))
+     */
+    private ActionWithLogProb sampleActionWithLogProb(Tensor state) {
+        AgentUtils.GaussianDistribution dist = this.policy.getDistribution(
+            state,
+            config.policyNetworkConfig().sigmaMin(),
+            config.policyNetworkConfig().sigmaMax()
+        );
+        Tensor rawAction = dist.sample(false); // Always sample for log_prob calculation during training
+        Tensor logProbRaw = dist.logProb(rawAction);
+
+        Tensor squashedAction = rawAction.tanh();
+
+        // Correction for tanh squashing: log(1 - tanh(x)^2) = 2 * (log(2) - x - softplus(-2x))
+        // Simpler: sum across action dimensions: log(1 - action_tanh^2). Add epsilon for stability.
+        // Each component of log_prob_squashed = log_prob_raw_component - log(1 - tanh(raw_action_component)^2)
+        // Summing log_prob_raw means it's already joint. Sum the correction term.
+        Tensor logProbSquashed = logProbRaw.sub(
+            rawAction.tanh().sqr().mul(-1).add(1).log().sum(-1, true) // sum over action dim
+        );
+        // Ensure logProbSquashed has shape (batch_size, 1) if logProbRaw was already summed.
+        // If dist.logProb returns (batch_size, action_dim), sum it first.
+        // GaussianPolicyNet.getDistribution().logProb() returns per-sample log_prob, (batch_size, 1)
+
+        return new ActionWithLogProb(squashedAction, logProbSquashed);
+    }
+
+    // Helper record for return value of sampleActionWithLogProb
+    // private record ActionWithLogProb(Tensor action, Tensor logProb) {} // Now in BasePolicyGradientAgent
+
+
+    @Override
+    protected ActionWithLogProb selectActionWithLogProb(Tensor state, boolean deterministic) {
+        if (deterministic) {
+            // For deterministic SAC action (e.g., evaluation), typically use the mean of the Gaussian
+            // and don't apply the tanh squashing's log_prob correction, or ensure log_prob isn't used.
+            // The `selectAction` method already handles deterministic mean.
+            // Log prob might not be meaningful or needed for deterministic eval path in `apply`.
+            try (var noGrad = Tensor.noGrad()) {
+                AgentUtils.GaussianDistribution dist = this.policy.getDistribution(
+                    state,
+                    config.policyNetworkConfig().sigmaMin(),
+                    config.policyNetworkConfig().sigmaMax()
+                );
+                Tensor rawAction = dist.getMean(); // Use mean for deterministic
+                Tensor squashedAction = rawAction.tanh();
+                // LogProb is tricky for deterministic mean if squashed.
+                // For 'apply' caching, if it's eval mode, logProb might not be stored/used anyway.
+                // Returning null for logProb in deterministic case seems safest if it's not well-defined for this path.
+                return new ActionWithLogProb(squashedAction.array(), null);
+            }
+        } else {
+            // Stochastic action with log_prob for training
+            AgentUtils.GaussianDistribution dist = this.policy.getDistribution(
+                state,
+                config.policyNetworkConfig().sigmaMin(),
+                config.policyNetworkConfig().sigmaMax()
+            );
+            Tensor rawAction = dist.sample(false); // Sample for stochastic
+            Tensor logProbRaw = dist.logProb(rawAction);
+
+            Tensor squashedAction = rawAction.tanh();
+            Tensor logProbSquashed = logProbRaw.sub(
+                rawAction.tanh().sqr().mul(-1).add(1).log().sum(-1, true)
+            );
+            return new ActionWithLogProb(squashedAction.array(), logProbSquashed);
+        }
+    }
+
+
+    @Override
+    public void recordExperience(Experience2 experience) {
+        Objects.requireNonNull(experience, "Experience cannot be null");
+        this.memory.add(experience);
+        // Updates are typically driven by having enough samples in the replay buffer.
+    }
+
+    @Override
+    public void update(long totalSteps) {
+        if (!this.trainingMode || this.memory.size() < config.memoryConfig().replayBufferConfig().batchSize()) {
+            return;
+        }
+
+        List<Experience2> batch = this.memory.sample(config.memoryConfig().replayBufferConfig().batchSize());
+        if (batch.isEmpty()) {
+            return;
+        }
+
+        ReplayBuffer.BatchTuple tensors = ReplayBuffer.experiencesToBatchTuple(batch);
+        Tensor states = tensors.states();
+        Tensor actions = tensors.actions(); // These are actions taken in env, already squashed.
+        Tensor rewards = tensors.rewards();
+        Tensor nextStates = tensors.nextStates();
+        Tensor dones = tensors.dones();     // 1.0 if done, 0.0 if not
+
+        float alpha = this.logAlpha.exp().scalar(); // Current temperature
+
+        // --- Update Q-functions (Critics) ---
+        Tensor targetQValues;
+        try (var noGrad = Tensor.noGrad()) {
+            ActionWithLogProb nextActionWithLogProb = sampleActionWithLogProb(nextStates);
+            Tensor nextActionsSquashed = nextActionWithLogProb.action();
+            Tensor logProbNextActions = nextActionWithLogProb.logProb();
+
+            // Target Q = min(Q_target1(s',a'), Q_target2(s',a')) - alpha * log_pi(a'|s')
+            Tensor targetQ1 = this.targetQNet1.apply(new Tensor[]{nextStates, nextActionsSquashed});
+            Tensor targetQ2 = this.targetQNet2.apply(new Tensor[]{nextStates, nextActionsSquashed});
+            Tensor minTargetQ = Tensor.min(targetQ1, targetQ2);
+
+            targetQValues = minTargetQ.sub(logProbNextActions.mul(alpha));
+
+            Tensor y_i = rewards.add(
+                dones.mul(-1).add(1) // (1 - dones)
+                    .mul(config.hyperparams().gamma())
+                    .mul(targetQValues)
+            ); // y_i = r + gamma * (1-done) * (min_Q_target(s',a') - alpha * log_pi(a'|s'))
+
+            // --- Q1 Loss ---
+            q1GradQueue.clear();
+            Tensor currentQ1 = this.qNet1.apply(new Tensor[]{states, actions});
+            Tensor q1Loss = currentQ1.loss(y_i.detach(), Tensor.Loss.MeanSquared);
+            q1Loss.minimize(q1GradQueue);
+            q1GradQueue.optimize(q1Optimizer);
+
+            // --- Q2 Loss ---
+            q2GradQueue.clear();
+            Tensor currentQ2 = this.qNet2.apply(new Tensor[]{states, actions});
+            Tensor q2Loss = currentQ2.loss(y_i.detach(), Tensor.Loss.MeanSquared);
+            q2Loss.minimize(q2GradQueue);
+            q2GradQueue.optimize(q2Optimizer);
+        }
+
+
+        // --- Update Policy (Actor) ---
+        policyGradQueue.clear();
+        ActionWithLogProb currentActionWithLogProb = sampleActionWithLogProb(states);
+        Tensor currentActionsSquashed = currentActionWithLogProb.action();
+        Tensor logProbCurrentActions = currentActionWithLogProb.logProb();
+
+        Tensor q1ForPolicyUpdate = this.qNet1.apply(new Tensor[]{states, currentActionsSquashed});
+        Tensor q2ForPolicyUpdate = this.qNet2.apply(new Tensor[]{states, currentActionsSquashed});
+        Tensor minQForPolicyUpdate = Tensor.min(q1ForPolicyUpdate, q2ForPolicyUpdate);
+
+        // Policy loss = alpha * log_pi(a|s) - min_Q(s,a)
+        Tensor policyLoss = logProbCurrentActions.mul(alpha).sub(minQForPolicyUpdate).mean();
+        policyLoss.minimize(policyGradQueue);
+        policyGradQueue.optimize(policyOptimizer);
+
+
+        // --- Update Alpha (Temperature) ---
+        if (config.sacHyperparams().automaticAlphaTuning() && !config.sacHyperparams().useFixedAlpha() && alphaOptimizer != null) {
+            alphaGradQueue.clear();
+            // Alpha loss = -log_alpha * (log_pi(a|s) + target_entropy).detach()
+            // Or, if optimizing log_alpha directly: loss = log_alpha * (-log_pi(a|s) - target_entropy).detach()
+            Tensor alphaLoss = this.logAlpha.mul(
+                    logProbCurrentActions.add(this.targetEntropy).detach().neg()
+            ).mean();
+            alphaLoss.minimize(alphaGradQueue);
+            alphaGradQueue.optimize(alphaOptimizer);
+        }
+
+        // --- Soft update target Q-networks ---
+        if (getUpdateCount() % config.sacHyperparams().targetUpdateInterval() == 0) {
+            Util.softUpdate(this.targetQNet1.getWeights(), this.qNet1.getWeights(), config.sacHyperparams().tau());
+            Util.softUpdate(this.targetQNet2.getWeights(), this.qNet2.getWeights(), config.sacHyperparams().tau());
+        }
+
+        incrementUpdateCount();
+    }
+
+
+    @Override
+    public Object getPolicy() {
+        return this.policy;
+    }
+
+    @Override
+    public Object getValueFunction() {
+        // SAC has Q-functions, not a single state-value function like VPG/PPO.
+        // Return one of them, or a structure containing both. For now, QNet1.
+        return this.qNet1;
+    }
+
+    public CriticNet getQNet1() { return this.qNet1; }
+    public CriticNet getQNet2() { return this.qNet2; }
+    public Tensor getLogAlpha() { return this.logAlpha; }
+
+
+    @Override
+    public Object getConfig() {
+        return this.config;
+    }
+
+    @Override
+    public void setTrainingMode(boolean training) {
+        super.setTrainingMode(training);
+        this.policy.train(training);
+        this.qNet1.train(training);
+        this.qNet2.train(training);
+        // Target networks are for stable targets, usually not in training mode for dropout/batchnorm effects
+        this.targetQNet1.train(false);
+        this.targetQNet2.train(false);
+    }
+
+    @Override
+    public void clearMemory() {
+        this.memory.clear();
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg3/StreamACAgent.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg3/StreamACAgent.java
@@ -1,0 +1,40 @@
+package jcog.tensor.rl.pg3;
+
+import jcog.tensor.Tensor;
+import jcog.tensor.rl.pg3.configs.VPGAgentConfig; // Using VPGAgentConfig as a base
+
+import java.util.function.UnaryOperator;
+
+// StreamAC is an Actor-Critic model. VPGAgent is the pg3 Actor-Critic.
+// This class would extend VPGAgent and potentially override update logic
+// or how experiences are processed if "streaming" implies continuous updates
+// rather than episodic ones.
+public class StreamACAgent extends VPGAgent {
+
+    // If StreamAC has a fundamentally different network structure or update rule
+    // not configurable via VPGAgentConfig, those would be implemented here.
+    public StreamACAgent(VPGAgentConfig config, int stateDim, int actionDim) {
+        super(config, stateDim, actionDim);
+
+        // TODO: Implement any specific modifications for StreamAC.
+        // This might involve:
+        // 1. Different network architectures (though VPGAgentConfig is fairly flexible).
+        // 2. Overriding the `update` method if the learning process is different
+        //    (e.g., truly streaming single-experience updates vs. batch/episode updates).
+        // 3. Custom handling of memory or experience processing.
+
+        System.err.println("StreamACAgent: Specific streaming logic and potential overrides need implementation.");
+    }
+
+    // Example: If StreamAC updates after every experience:
+    // @Override
+    // public void recordExperience(Experience2 experience) {
+    //     super.recordExperience(experience); // Adds to memory
+    //     if (isTrainingMode() && this.memory.size() >= 1) { // Or some small batch size
+    //         update(0); // Or however totalSteps is tracked
+    //         // May or may not clear memory depending on StreamAC's exact nature (on-policy vs. sliding window off-policy)
+    //         if (config.memoryConfig().episodeLength() == null || config.memoryConfig().episodeLength() <=1 ) // pseudo-config check
+    //            this.memory.clear();
+    //     }
+    // }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg3/VPGAgent.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg3/VPGAgent.java
@@ -181,4 +181,13 @@ public class VPGAgent extends BasePolicyGradientAgent {
     public void clearMemory() {
         this.memory.clear();
     }
+
+    @Override
+    protected ActionWithLogProb selectActionWithLogProb(Tensor state, boolean deterministic) {
+        // VPG, like Reinforce, calculates logProbs during its update phase.
+        // The selectAction method is sufficient for action selection.
+        // LogProb can be null for the base class's caching mechanism if not used by VPG's Experience2.
+        double[] action = selectAction(state, deterministic);
+        return new ActionWithLogProb(action, null);
+    }
 }

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg3/configs/DDPGAgentConfig.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg3/configs/DDPGAgentConfig.java
@@ -1,0 +1,77 @@
+package jcog.tensor.rl.pg3.configs;
+
+import jcog.tensor.rl.pg.util.ReplayBuffer2; // Assuming we might use or adapt this
+
+/**
+ * Configuration for the DDPG (Deep Deterministic Policy Gradient) agent.
+ * <p>
+ * This class encapsulates all hyperparameters and structural settings for the DDPG agent,
+ * its actor and critic networks, optimizers, and replay buffer.
+ */
+public record DDPGAgentConfig(
+    NetworkConfig actorNetworkConfig,
+    NetworkConfig criticNetworkConfig,
+    OptimizerConfig actorOptimizerConfig,
+    OptimizerConfig criticOptimizerConfig,
+    MemoryConfig memoryConfig, // Will likely need specific replay buffer settings
+    HyperparamConfig hyperparams, // Common hyperparameters like gamma
+    DDPGHyperparams ddpgHyperparams // DDPG specific ones like tau, noise
+) {
+
+    /**
+     * DDPG-specific hyperparameters.
+     *
+     * @param tau                Rate for soft target updates (polyak averaging).
+     * @param actionNoiseStddev  Standard deviation for action noise (e.g., Ornstein-Uhlenbeck or Gaussian).
+     * @param targetPolicyNoise  Standard deviation for noise added to target policy actions (for TD3 extension, optional).
+     * @param targetNoiseClip    Clipping range for target policy noise (for TD3 extension, optional).
+     * @param policyUpdateFreq   Frequency of policy updates compared to critic updates.
+     */
+    public record DDPGHyperparams(
+        Float tau,
+        Float actionNoiseStddev,
+        @Deprecated Float targetPolicyNoise, // More relevant for TD3
+        @Deprecated Float targetNoiseClip,   // More relevant for TD3
+        Integer policyUpdateFreq
+    ) {
+        public DDPGHyperparams {
+            if (tau == null) tau = 0.005f;
+            if (actionNoiseStddev == null) actionNoiseStddev = 0.1f;
+            if (targetPolicyNoise == null) targetPolicyNoise = 0.2f; // Default for TD3, less critical for DDPG
+            if (targetNoiseClip == null) targetNoiseClip = 0.5f;   // Default for TD3
+            if (policyUpdateFreq == null) policyUpdateFreq = 1; // Standard DDPG updates actor and critic together usually
+        }
+    }
+
+    public DDPGAgentConfig {
+        if (actorNetworkConfig == null) throw new IllegalArgumentException("Actor network config cannot be null");
+        if (criticNetworkConfig == null) throw new IllegalArgumentException("Critic network config cannot be null");
+        if (actorOptimizerConfig == null) actorOptimizerConfig = new OptimizerConfig(OptimizerType.ADAM, 1e-4f, null, null);
+        if (criticOptimizerConfig == null) criticOptimizerConfig = new OptimizerConfig(OptimizerType.ADAM, 1e-3f, null, null);
+        if (memoryConfig == null) {
+            // DDPG needs a replay buffer.
+            // Let's define a default replay buffer config within MemoryConfig or expect it to be set.
+            // For now, assuming MemoryConfig can handle replay buffer specifics or will be adapted.
+            // Placeholder, this might need a more specific ReplayBufferConfig record.
+             MemoryConfig.ReplayBufferConfig replayDefaults = new MemoryConfig.ReplayBufferConfig(1_000_000, 64);
+             memoryConfig = new MemoryConfig(null, replayDefaults, null); // Episode length null for off-policy
+        }
+        if (hyperparams == null) hyperparams = new HyperparamConfig(
+            0.99f, null, null, false, false, 0.0f, 1 // Default gamma, other PG params less relevant
+        );
+        if (ddpgHyperparams == null) ddpgHyperparams = new DDPGHyperparams(null, null, null, null, null);
+    }
+
+    // Convenience constructor with some defaults
+    public DDPGAgentConfig(int stateDim, int actionDim) {
+        this(
+            new NetworkConfig(1e-4f, 256, 256), // actor
+            new NetworkConfig(1e-3f, 256, 256), // critic
+            new OptimizerConfig(OptimizerConfig.OptimizerType.ADAM, 1e-4f, null, null),
+            new OptimizerConfig(OptimizerConfig.OptimizerType.ADAM, 1e-3f, null, null),
+            new MemoryConfig(null, new MemoryConfig.ReplayBufferConfig(1_000_000, 64), null),
+            new HyperparamConfig(0.99f, null, null, false, false, 0.0f,1),
+            new DDPGHyperparams(0.005f, 0.1f, 0.2f, 0.5f, 1)
+        );
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg3/configs/SACAgentConfig.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg3/configs/SACAgentConfig.java
@@ -1,0 +1,86 @@
+package jcog.tensor.rl.pg3.configs;
+
+/**
+ * Configuration for the SAC (Soft Actor-Critic) agent.
+ * <p>
+ * This class encapsulates all hyperparameters and structural settings for the SAC agent,
+ * its actor (policy), critics (Q-networks), and entropy temperature.
+ */
+public record SACAgentConfig(
+    NetworkConfig policyNetworkConfig,   // For the stochastic policy (actor)
+    NetworkConfig qNetworkConfig,        // For the Q-networks (critics)
+    OptimizerConfig policyOptimizerConfig,
+    OptimizerConfig qOptimizerConfig,
+    OptimizerConfig alphaOptimizerConfig,  // For automatic temperature tuning
+    MemoryConfig memoryConfig,
+    HyperparamConfig hyperparams,        // Common ones like gamma
+    SACHyperparams sacHyperparams        // SAC specific ones like tau, alpha, target update interval
+) {
+
+    /**
+     * SAC-specific hyperparameters.
+     *
+     * @param tau                       Rate for soft target updates (polyak averaging) for Q-networks.
+     * @param initialAlpha              Initial value for the temperature parameter (entropy coefficient).
+     *                                  If null and automaticAlphaTuning is true, a heuristic might be used.
+     * @param automaticAlphaTuning      Whether to automatically tune the temperature parameter 'alpha'.
+     * @param targetEntropy             The target entropy for automatic alpha tuning. If null, typically defaults
+     *                                  to -action_dimension.
+     * @param targetUpdateInterval      Frequency of updates for the target Q-networks (in terms of critic updates).
+     * @param useFixedAlpha             If true, alpha is fixed to initialAlpha and not tuned. Overrides automaticAlphaTuning.
+     */
+    public record SACHyperparams(
+        Float tau,
+        Float initialAlpha,
+        Boolean automaticAlphaTuning,
+        Float targetEntropy, // Can be null, agent will use default based on actionDim
+        Integer targetUpdateInterval,
+        Boolean useFixedAlpha
+    ) {
+        public SACHyperparams {
+            if (tau == null) tau = 0.005f;
+            if (initialAlpha == null) initialAlpha = 0.2f; // Common starting point
+            if (automaticAlphaTuning == null) automaticAlphaTuning = true; // SAC often uses tuning
+            // targetEntropy is often set dynamically based on action dimension, so null is acceptable.
+            if (targetUpdateInterval == null) targetUpdateInterval = 1; // How often to update target Q networks
+            if (useFixedAlpha == null) useFixedAlpha = false;
+
+            if (useFixedAlpha && automaticAlphaTuning) {
+                //System.err.println("SACConfig: useFixedAlpha is true, so automaticAlphaTuning will be ignored.");
+                //automaticAlphaTuning = false; // Ensure consistency if fixed alpha is chosen
+            }
+        }
+    }
+
+    public SACAgentConfig {
+        if (policyNetworkConfig == null) throw new IllegalArgumentException("Policy network config cannot be null");
+        if (qNetworkConfig == null) throw new IllegalArgumentException("Q-network config cannot be null");
+
+        if (policyOptimizerConfig == null) policyOptimizerConfig = new OptimizerConfig(OptimizerConfig.OptimizerType.ADAM, 3e-4f, null, null);
+        if (qOptimizerConfig == null) qOptimizerConfig = new OptimizerConfig(OptimizerConfig.OptimizerType.ADAM, 3e-4f, null, null);
+        if (alphaOptimizerConfig == null) alphaOptimizerConfig = new OptimizerConfig(OptimizerConfig.OptimizerType.ADAM, 3e-4f, null, null); // For alpha tuning
+
+        if (memoryConfig == null) {
+            MemoryConfig.ReplayBufferConfig replayDefaults = new MemoryConfig.ReplayBufferConfig(1_000_000, 256); // Common batch size for SAC
+            memoryConfig = new MemoryConfig(null, replayDefaults, null); // Episode length null for off-policy
+        }
+        if (hyperparams == null) hyperparams = new HyperparamConfig(
+            0.99f, null, null, false, false, 0.0f, 1 // Default gamma
+        );
+        if (sacHyperparams == null) sacHyperparams = new SACHyperparams(null, null, null, null, null, null);
+    }
+
+    // Convenience constructor with some defaults
+    public SACAgentConfig(int stateDim, int actionDim) {
+        this(
+            new NetworkConfig(3e-4f, 256, 256), // policy
+            new NetworkConfig(3e-4f, 256, 256), // q-networks
+            new OptimizerConfig(OptimizerConfig.OptimizerType.ADAM, 3e-4f, null, null), // policy opt
+            new OptimizerConfig(OptimizerConfig.OptimizerType.ADAM, 3e-4f, null, null), // q opt
+            new OptimizerConfig(OptimizerConfig.OptimizerType.ADAM, 3e-4f, null, null), // alpha opt
+            new MemoryConfig(null, new MemoryConfig.ReplayBufferConfig(1_000_000, 256), null),
+            new HyperparamConfig(0.99f, null, null, false, false, 0.0f, 1),
+            new SACHyperparams(0.005f, 0.2f, true, (float) -actionDim, 1, false) // targetEntropy often -actionDim
+        );
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg3/memory/ReplayBuffer.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg3/memory/ReplayBuffer.java
@@ -1,0 +1,209 @@
+package jcog.tensor.rl.pg3.memory;
+
+import jcog.list.FasterShuffle;
+import jcog.tensor.Tensor;
+import jcog.tensor.rl.pg.util.Experience2;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * A simple replay buffer for off-policy reinforcement learning agents.
+ * It stores experiences and allows random sampling of batches.
+ * This version is adapted for use with {@link Experience2} objects.
+ */
+public class ReplayBuffer implements AgentMemory {
+
+    private final List<Experience2> buffer;
+    private final int capacity;
+    private int position;
+    private final Random random;
+
+    /**
+     * Constructs a ReplayBuffer.
+     *
+     * @param capacity The maximum number of experiences the buffer can hold.
+     */
+    public ReplayBuffer(int capacity) {
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("Capacity must be positive.");
+        }
+        this.capacity = capacity;
+        this.buffer = new ArrayList<>(capacity);
+        this.position = 0;
+        this.random = new Random(); // Consider making Random injectable for reproducibility
+    }
+
+    /**
+     * Adds an experience to the buffer. If the buffer is full, the oldest experience is overwritten.
+     *
+     * @param experience The experience to add.
+     */
+    @Override
+    public void add(Experience2 experience) {
+        if (this.buffer.size() < this.capacity) {
+            this.buffer.add(experience);
+        } else {
+            this.buffer.set(this.position, experience);
+        }
+        this.position = (this.position + 1) % this.capacity;
+    }
+
+    /**
+     * Samples a batch of experiences randomly from the buffer.
+     *
+     * @param batchSize The number of experiences to sample.
+     * @return A list of sampled experiences. Returns an empty list if the buffer contains fewer
+     *         experiences than the batch size.
+     */
+    @Override
+    public List<Experience2> sample(int batchSize) {
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("Batch size must be positive.");
+        }
+        if (this.buffer.size() < batchSize) {
+            // Not enough samples in buffer yet, return empty or partial batch based on desired behavior.
+            // Returning empty list if not enough, common approach.
+            return Collections.emptyList();
+        }
+
+        List<Experience2> batch = new ArrayList<>(batchSize);
+        for (int i = 0; i < batchSize; i++) {
+            batch.add(this.buffer.get(this.random.nextInt(this.buffer.size())));
+        }
+        return batch;
+    }
+
+    /**
+     * Samples a batch of experiences randomly from the buffer using a faster shuffle.
+     * This is an alternative to repeated random index selection.
+     *
+     * @param batchSize The number of experiences to sample.
+     * @return A list of sampled experiences.
+     */
+    public List<Experience2> sampleFaster(int batchSize) {
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("Batch size must be positive.");
+        }
+        int currentSize = this.buffer.size();
+        if (currentSize < batchSize) {
+            return Collections.emptyList(); // Or handle as desired, e.g., return all available
+        }
+
+        // Efficiently sample 'batchSize' distinct elements
+        // Create a temporary list of indices or shuffle a sublist if buffer is very large
+        // For moderately sized buffers, shuffling a copy of references is okay.
+        List<Experience2> shuffledBuffer = new ArrayList<>(this.buffer);
+        FasterShuffle.shuffle(shuffledBuffer, this.random); // Or Collections.shuffle
+
+        return new ArrayList<>(shuffledBuffer.subList(0, batchSize));
+    }
+
+
+    /**
+     * Returns all experiences currently in the buffer.
+     * This is typically used by on-policy algorithms or for specific debugging/analysis,
+     * less so for standard off-policy replay buffer sampling.
+     *
+     * @return A list containing all experiences in the buffer.
+     */
+    @Override
+    public List<Experience2> getAll() {
+        return new ArrayList<>(this.buffer); // Return a copy
+    }
+
+    /**
+     * Returns the current number of experiences in the buffer.
+     *
+     * @return The size of the buffer.
+     */
+    @Override
+    public int size() {
+        return this.buffer.size();
+    }
+
+    /**
+     * Returns the capacity of the buffer.
+     *
+     * @return The maximum capacity.
+     */
+    public int capacity() {
+        return this.capacity;
+    }
+
+    /**
+     * Clears all experiences from the buffer.
+     */
+    @Override
+    public void clear() {
+        this.buffer.clear();
+        this.position = 0;
+    }
+
+    /**
+     * Converts a list of Experience2 objects into separate lists of Tensors for states, actions, etc.
+     * This is a utility method that can be helpful for preparing batches for network processing.
+     *
+     * @param batch The list of Experience2 objects.
+     * @return A BatchTuple containing Tensors for states, actions, rewards, nextStates, dones, and oldLogProbs.
+     */
+    public static BatchTuple experiencesToBatchTuple(List<Experience2> batch) {
+        if (batch == null || batch.isEmpty()) {
+            return new BatchTuple(null, null, null, null, null, null);
+        }
+
+        List<Tensor> states = new ArrayList<>(batch.size());
+        List<Tensor> actions = new ArrayList<>(batch.size());
+        List<Float> rewards = new ArrayList<>(batch.size());
+        List<Tensor> nextStates = new ArrayList<>(batch.size());
+        List<Boolean> dones = new ArrayList<>(batch.size());
+        List<Tensor> oldLogProbs = new ArrayList<>(batch.size()); // May be null for some experiences
+
+        for (Experience2 exp : batch) {
+            states.add(exp.state());
+            actions.add(Tensor.row(exp.action())); // Assuming action is double[]
+            rewards.add(exp.reward());
+            nextStates.add(exp.nextState());
+            dones.add(exp.done());
+            if (exp.oldLogProb() != null) {
+                oldLogProbs.add(exp.oldLogProb());
+            }
+        }
+
+        Tensor statesTensor = states.isEmpty() ? null : Tensor.concatRows(states);
+        Tensor actionsTensor = actions.isEmpty() ? null : Tensor.concatRows(actions);
+        Tensor rewardsTensor = rewards.isEmpty() ? null : Tensor.vector(rewards.stream().mapToDouble(f -> f).toArray()).transpose();
+        Tensor nextStatesTensor = nextStates.stream().anyMatch(java.util.Objects::isNull) ? null : Tensor.concatRows(nextStates.stream().filter(java.util.Objects::nonNull).toList());
+
+        // Handle cases where not all experiences have nextState (e.g. terminal states might have null nextState in Experience2)
+        // This requires careful handling by the caller if nextStatesTensor can have fewer rows.
+        // A more robust way is to ensure nextState is always present, perhaps a zero tensor for terminal.
+        // For now, we filter nulls, which might lead to mismatched batch sizes if not handled.
+        // A common practice: if exp.done(), nextState might be irrelevant or a conventional zero tensor.
+        // Let's assume for now that if nextState is null, it's a terminal state.
+        // The `donesTensor` will indicate this.
+
+        Tensor donesTensor = dones.isEmpty() ? null : Tensor.vector(dones.stream().mapToDouble(b -> b ? 1.0 : 0.0).toArray()).transpose();
+        Tensor oldLogProbsTensor = oldLogProbs.isEmpty() ? null : Tensor.concatRows(oldLogProbs);
+
+        // Adjust nextStatesTensor to ensure it has the same number of rows, padding with zeros for terminal states if necessary.
+        // This simplified version just concatenates non-null nextStates. The user of BatchTuple must be aware.
+        // A more robust solution would involve ensuring all lists in BatchTuple have the same row count.
+
+        return new BatchTuple(statesTensor, actionsTensor, rewardsTensor, nextStatesTensor, donesTensor, oldLogProbsTensor);
+    }
+
+    /**
+     * A tuple to hold batched experiences as Tensors.
+     */
+    public record BatchTuple(
+        Tensor states,
+        Tensor actions,
+        Tensor rewards,
+        Tensor nextStates,
+        Tensor dones,
+        Tensor oldLogProbs // Relevant for PPO, might be null for DDPG experiences
+    ) {}
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg3/networks/CriticNet.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg3/networks/CriticNet.java
@@ -1,0 +1,189 @@
+package jcog.tensor.rl.pg3.networks;
+
+import jcog.tensor.Tensor;
+import jcog.tensor.apadani.MetaWeights;
+import jcog.tensor.rl.pg3.configs.NetworkConfig;
+import jcog.tensor.rl.util.RLNetworkUtils;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+
+/**
+ * A neural network model that estimates the Q-value (state-action value).
+ * This is typically used as the critic network in Actor-Critic algorithms like DDPG and SAC.
+ * The network architecture usually processes the state through some layers, then concatenates
+ * the action, and passes this combined representation through further layers to output a single Q-value.
+ */
+public class CriticNet extends MetaWeights<Tensor[], Tensor> { // Input is Tensor[]{state, action}
+
+    private final NetworkConfig config;
+    private final UnaryOperator<Tensor> network;
+    private final int stateDim;
+    private final int actionDim;
+
+    /**
+     * Constructs a CriticNet.
+     *
+     * @param config    The network configuration.
+     * @param stateDim  The dimensionality of the state input.
+     * @param actionDim The dimensionality of the action input.
+     */
+    public CriticNet(NetworkConfig config, int stateDim, int actionDim) {
+        Objects.requireNonNull(config, "Network config cannot be null");
+        if (stateDim <= 0) throw new IllegalArgumentException("State dimension must be positive.");
+        if (actionDim <= 0) throw new IllegalArgumentException("Action dimension must be positive.");
+
+        this.config = config;
+        this.stateDim = stateDim;
+        this.actionDim = actionDim;
+
+        // Standard DDPG critic architecture:
+        // Input state -> Layer1 -> Activation -> [Concat with Action] -> Layer2 -> Activation -> Output Q-value
+        // We need to define how layers are structured around the action concatenation point.
+        // A common approach is to have one or more layers process the state first,
+        // then concatenate actions, then pass through more layers.
+
+        // Example: state -> fc1_dims -> action_input_layer_dims -> fc2_dims -> 1 (Q-value)
+        // Let's assume hiddenLayerSizes refers to layers after state processing and action concatenation.
+        // If hiddenLayerSizes = [256, 256], then:
+        // state -> L1 (e.g., 256) -> concat(action) -> L2 (256) -> L3 (256) -> Q-value
+        // Or, state -> L1_s, action -> L1_a, concat(L1_s_out, L1_a_out) -> L2 -> Q-value (more complex)
+
+        // Simpler approach: state -> fc1 -> relu -> concat(output_fc1, action) -> fc2 -> relu -> fc3 -> Q-value
+        // Let config.hiddenLayerSizes() define the layers *after* state and action are combined.
+        // The first hidden layer size in config could be the output size for the state's initial processing.
+
+        if (config.hiddenLayerSizes() == null || config.hiddenLayerSizes().length < 1) {
+            throw new IllegalArgumentException("CriticNet requires at least one hidden layer size in NetworkConfig for post-concatenation processing.");
+        }
+
+        // Layer to process state before action concatenation
+        int firstStateLayerOutputDim = config.hiddenLayerSizes()[0]; // Use first hidden size for state pre-processing output
+        UnaryOperator<Tensor> stateProcessingLayer = RLNetworkUtils.buildLinearLayer(
+            stateDim, firstStateLayerOutputDim, config.hiddenActivation(), config.useLayerNorm(), true // bias
+        );
+
+        // Layers after state-action concatenation
+        // Input to these layers will be firstStateLayerOutputDim + actionDim
+        List<Integer> postConcatLayerSizes = RLNetworkUtils.buildLayerSizes(
+            firstStateLayerOutputDim + actionDim,
+            // Pass remaining hidden layer sizes, or just one if only one was specified for state processing
+            config.hiddenLayerSizes().length > 1 ?
+                java.util.Arrays.copyOfRange(config.hiddenLayerSizes(), 1, config.hiddenLayerSizes().length)
+                : new int[]{}, // If only one hidden size, means it was for state, post-concat goes straight to output layer or one more hidden
+            1 // Output dimension is 1 (the Q-value)
+        );
+
+        // If hiddenLayerSizes had only one entry, it was used for state processing.
+        // Add another layer of similar size before output if postConcatLayerSizes is only [1]
+        if (postConcatLayerSizes.size() == 1 && postConcatLayerSizes.get(0) == 1 && config.hiddenLayerSizes().length ==1) {
+             postConcatLayerSizes = List.of(firstStateLayerOutputDim, 1);
+        }
+
+
+        UnaryOperator<Tensor> postConcatNetwork = RLNetworkUtils.buildSequentialNetwork(
+            postConcatLayerSizes,
+            config.hiddenActivation(),
+            config.outputActivation() != null ? config.outputActivation() : Tensor.LINEAR, // Q-values are typically unbounded
+            config.useLayerNorm(),
+            config.useBiasInLastLayer()
+        );
+
+        this.network = stateAndAction -> {
+            Tensor state = stateAndAction[0];
+            Tensor action = stateAndAction[1];
+
+            Tensor processedState = stateProcessingLayer.apply(state);
+            Tensor concatenated = Tensor.concatColumns(processedState, action);
+            return postConcatNetwork.apply(concatenated);
+        };
+
+
+        // Initialize weights if a specific initializer is configured
+        // This needs to be applied carefully if network is composite.
+        // Assuming stateProcessingLayer and postConcatNetwork handle their own params internally via RLNetworkUtils.
+        if (config.weightInitializer() != null) {
+            RLNetworkUtils.initializeWeights(stateProcessingLayer, config.weightInitializer());
+            RLNetworkUtils.initializeWeights(postConcatNetwork, config.weightInitializer());
+        }
+
+        // Collect parameters
+        getWeights().addAll(Tensor.params(stateProcessingLayer));
+        getWeights().addAll(Tensor.params(postConcatNetwork));
+        //train(true); // Set to training mode by default
+    }
+
+    /**
+     * Performs a forward pass through the network to get the Q-value for the given state-action pair.
+     *
+     * @param stateAction A Tensor array where stateAction[0] is the state and stateAction[1] is the action.
+     *                    Both state and action should be row vectors (batch_size x dim).
+     * @return A tensor representing the Q-value(s), typically of shape (batch_size, 1).
+     */
+    @Override
+    public Tensor apply(Tensor[] stateAction) {
+        if (stateAction == null || stateAction.length != 2) {
+            throw new IllegalArgumentException("Input must be a Tensor array of length 2: {state, action}");
+        }
+        Tensor state = stateAction[0];
+        Tensor action = stateAction[1];
+
+        if (state.cols() != this.stateDim) {
+            throw new IllegalArgumentException("State tensor has incorrect column dimension. Expected " + this.stateDim + ", got " + state.cols());
+        }
+        if (action.cols() != this.actionDim) {
+            throw new IllegalArgumentException("Action tensor has incorrect column dimension. Expected " + this.actionDim + ", got " + action.cols());
+        }
+        if (state.rows() != action.rows()) {
+            throw new IllegalArgumentException("State and Action tensors must have the same number of rows (batch size).");
+        }
+
+        return this.network.apply(new Tensor[]{state, action});
+    }
+
+    /**
+     * Gets the configuration of this network.
+     * @return The {@link NetworkConfig} instance.
+     */
+    public NetworkConfig getConfig() {
+        return this.config;
+    }
+
+    /**
+     * Sets the training mode for the network.
+     * @param training True to set to training mode, false for evaluation mode.
+     */
+    public void train(boolean training) {
+        // This needs to be propagated to the underlying network components
+        // if they have layers like Dropout or BatchNorm.
+        // RLNetworkUtils.buildSequentialNetwork handles this for its layers.
+        // If stateProcessingLayer is a complex model, it might need its own train(boolean) call.
+        // For now, assuming RLNetworkUtils handles layers within the built components.
+        if (this.network instanceof MetaWeights) { // Should not be the case here with current build
+             ((MetaWeights<?,?>)this.network).getWeights().forEach(p -> { if (p instanceof MetaWeights) ((MetaWeights<?,?>)p).train(training);});
+        }
+        // More robustly, if stateProcessingLayer and postConcatNetwork are accessible and are MetaWeights based:
+        // RLNetworkUtils.setNetworkTrainMode(stateProcessingLayer, training);
+        // RLNetworkUtils.setNetworkTrainMode(postConcatNetwork, training);
+        // For now, this is a simplified version. If specific layers (BatchNorm, Dropout) are directly
+        // part of stateProcessingLayer or postConcatNetwork, their train() methods are called by
+        // the RLNetworkUtils.setNetworkTrainMode if it's applied to them.
+        // The MetaWeights.train() method itself doesn't exist.
+        // We need to ensure that `RLNetworkUtils.setNetworkTrainMode` is called on the actual UnaryOperator<Tensor>
+        // instances that make up the network if they contain trainable layers affected by mode.
+        // The current `network` field is a lambda, so we'd need access to its components.
+        // This detail is important if layer norm or dropout is used.
+        // For simplicity, let's assume `RLNetworkUtils.buildSequentialNetwork` and `buildLinearLayer`
+        // construct layers that correctly respond to `Tensor.setTrain(boolean)` if it's called on them.
+        // The current Tensor framework might handle this via a global training flag or per-tensor graph.
+        // Let's assume, for now, that individual layers used (Linear, etc.) correctly handle training mode
+        // if their `train(boolean)` is called, or if Tensor library has a global mode.
+        // The `MetaWeights` class itself does not have a `train` method.
+        // The `train` method is typically on the model that *uses* the MetaWeights (like GaussianPolicyNet).
+
+        // TODO: Clarify how training mode is propagated to layers created by RLNetworkUtils.
+        // For now, this method is a placeholder if deeper propagation is needed.
+        // If layers are simple Linear layers without Dropout/BatchNorm, this might not be critical.
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg3/networks/DeterministicPolicyNet.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg3/networks/DeterministicPolicyNet.java
@@ -1,0 +1,99 @@
+package jcog.tensor.rl.pg3.networks;
+
+import jcog.tensor.Tensor;
+import jcog.tensor.apadani.MetaWeights;
+import jcog.tensor.rl.pg3.configs.NetworkConfig;
+import jcog.tensor.rl.util.RLNetworkUtils;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+
+/**
+ * A neural network model that outputs a deterministic action given a state.
+ * This is typically used as the actor network in DDPG algorithms.
+ * The network architecture consists of a series of hidden layers followed by an output layer
+ * that produces the action. The output activation is typically Tanh to constrain actions
+ * within a specific range (e.g., [-1, 1]).
+ */
+public class DeterministicPolicyNet extends MetaWeights<Tensor, Tensor> {
+
+    private final NetworkConfig config;
+    private final UnaryOperator<Tensor> network;
+    private final int actionDim;
+
+    /**
+     * Constructs a DeterministicPolicyNet.
+     *
+     * @param config    The network configuration specifying learning rate, hidden layer sizes, etc.
+     * @param stateDim  The dimensionality of the state input.
+     * @param actionDim The dimensionality of the action output.
+     */
+    public DeterministicPolicyNet(NetworkConfig config, int stateDim, int actionDim) {
+        Objects.requireNonNull(config, "Network config cannot be null");
+        if (stateDim <= 0) throw new IllegalArgumentException("State dimension must be positive.");
+        if (actionDim <= 0) throw new IllegalArgumentException("Action dimension must be positive.");
+
+        this.config = config;
+        this.actionDim = actionDim;
+
+        List<Integer> layerSizes = RLNetworkUtils.buildLayerSizes(stateDim, config.hiddenLayerSizes(), actionDim);
+
+        // For DDPG, the actor's output activation is often tanh to bound actions (e.g., to [-1, 1]).
+        // The layers leading up to it can use ReLU or other activations.
+        this.network = RLNetworkUtils.buildSequentialNetwork(
+            layerSizes,
+            config.hiddenActivation(),
+            config.outputActivation() != null ? config.outputActivation() : Tensor::tanh, // Default to tanh for action output
+            config.useLayerNorm(),
+            config.useBiasInLastLayer()
+        );
+
+        // Initialize weights if a specific initializer is configured
+        if (config.weightInitializer() != null) {
+            RLNetworkUtils.initializeWeights(this.network, config.weightInitializer());
+        }
+
+        // Collect parameters from the network
+        getWeights().addAll(Tensor.params(this.network));
+        //train(true); // Set to training mode by default, can be changed by agent
+    }
+
+    /**
+     * Performs a forward pass through the network to get a deterministic action for the given state.
+     *
+     * @param state The input state tensor.
+     * @return A tensor representing the deterministic action.
+     */
+    @Override
+    public Tensor apply(Tensor state) {
+        return this.network.apply(state);
+    }
+
+    /**
+     * Gets the configuration of this network.
+     *
+     * @return The {@link NetworkConfig} instance.
+     */
+    public NetworkConfig getConfig() {
+        return this.config;
+    }
+
+    /**
+     * Gets the dimensionality of the action output by this network.
+     * @return The action dimension.
+     */
+    public int getActionDim() {
+        return this.actionDim;
+    }
+
+    /**
+     * Sets the training mode for the network.
+     * This typically propagates to layers like Dropout or BatchNorm if they are used.
+     *
+     * @param training True to set to training mode, false for evaluation mode.
+     */
+    public void train(boolean training) {
+        RLNetworkUtils.setNetworkTrainMode(this.network, training);
+    }
+}


### PR DESCRIPTION
- Implemented DDPGAgent and SACAgent in the pg3 framework, including their specific network types (DeterministicPolicyNet, CriticNet) and configurations.
- Added ReplayBuffer to pg3.memory.
- Implemented the Agent.apply method in BasePolicyGradientAgent and all concrete pg3 agents, including log probability caching for PPO/SAC and assuming done=false for continuous operation.
- Updated factory methods in Agents.java to use the new pg3 ReinforceAgent, VPGAgent, PPOAgent, DDPGAgent, and SACAgent.
- Created skeleton classes for ReinforceDNCAgent, ReinforceODEAgent, and StreamACAgent extending respective pg3 base agents, and updated factory methods in Agents.java to point to these new skeletons.
- Made pg3 agents (PPOAgent, SACAgent) use the protected selectActionWithLogProb from BasePolicyGradientAgent.