### PR TITLE
feat: Implement metric collection system for pg2 agents

### DIFF
--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg2/stats/DefaultMetricCollector.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg2/stats/DefaultMetricCollector.java
@@ -1,0 +1,97 @@
+package jcog.tensor.rl.pg2.stats;
+
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A default implementation of {@link MetricCollector}.
+ * It stores the latest value of each metric and summary statistics (mean, min, max, count).
+ * It does not store the full history of metrics by default to save memory, but can notify a
+ * {@link MetricListener} for custom processing or storage of all values.
+ * This implementation is thread-safe for recording and retrieval.
+ */
+public class DefaultMetricCollector implements MetricCollector {
+
+    private final Map<String, Pair<Long, Double>> latestMetrics;
+    private final Map<String, MetricSummary> metricSummaries;
+    private MetricListener metricListener;
+
+    public DefaultMetricCollector() {
+        // Use ConcurrentHashMap for thread-safety, as agents might be updated or queried from different threads.
+        this.latestMetrics = new ConcurrentHashMap<>();
+        this.metricSummaries = new ConcurrentHashMap<>();
+        this.metricListener = null;
+    }
+
+    @Override
+    public void record(String metricName, double value, long step) {
+        if (metricName == null || metricName.trim().isEmpty()) {
+            // Or throw IllegalArgumentException, depending on desired strictness
+            System.err.println("Metric name cannot be null or empty.");
+            return;
+        }
+        if (Double.isNaN(value) || Double.isInfinite(value)) {
+            // Or throw IllegalArgumentException
+            System.err.println("Metric value cannot be NaN or Infinite for metric: " + metricName);
+            return;
+        }
+
+        latestMetrics.put(metricName, Tuples.pair(step, value));
+
+        MetricSummary summary = metricSummaries.computeIfAbsent(metricName, k -> new MetricSummary());
+        summary.update(value);
+
+        // Notify listener if one is set
+        MetricListener currentListener = this.metricListener; // Read volatile/final field once
+        if (currentListener != null) {
+            try {
+                currentListener.onMetricRecorded(metricName, step, value);
+            } catch (Exception e) {
+                // Log or handle listener exceptions appropriately
+                System.err.println("MetricListener threw an exception: " + e.getMessage());
+                e.printStackTrace(System.err);
+            }
+        }
+    }
+
+    @Override
+    public void setMetricListener(MetricListener listener) {
+        this.metricListener = listener;
+    }
+
+    @Override
+    public Optional<Pair<Long, Double>> getLatestMetric(String metricName) {
+        return Optional.ofNullable(latestMetrics.get(metricName));
+    }
+
+    @Override
+    public Optional<MetricSummary> getSummary(String metricName) {
+        return Optional.ofNullable(metricSummaries.get(metricName));
+    }
+
+    @Override
+    public Map<String, MetricSummary> getAllSummaries() {
+        // Return an immutable copy to prevent external modification
+        return Collections.unmodifiableMap(new HashMap<>(metricSummaries));
+    }
+
+    @Override
+    public void reset() {
+        latestMetrics.clear();
+        metricSummaries.clear();
+        // Do not reset the listener, as it might be intended to persist across resets of data.
+        // If listener reset is desired, a separate method or explicit null set is better.
+        // Based on plan "Resets the collector, clearing all recorded metrics, summaries, and removing any listener."
+        // -> so, listener should be removed.
+        this.metricListener = null;
+
+        // If MetricSummary objects themselves need reset (if they were reused from a pool, not here)
+        // metricSummaries.values().forEach(MetricSummary::reset); // Not needed with current new MetricSummary()
+    }
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg2/stats/MetricCollector.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg2/stats/MetricCollector.java
@@ -1,0 +1,64 @@
+package jcog.tensor.rl.pg2.stats;
+
+import jcog.data.map.LongKeyCache; // Assuming Pair is from a library like Apache Commons Lang or a custom one
+import org.eclipse.collections.api.tuple.Pair; // Using Eclipse Collections Pair
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Interface for collecting and retrieving metrics during an agent's training or evaluation.
+ * Implementations can choose how to store and process these metrics.
+ */
+public interface MetricCollector {
+
+    /**
+     * Records a metric value at a specific step.
+     *
+     * @param metricName The name of the metric (e.g., "policy_loss", "reward").
+     * @param value      The value of the metric.
+     * @param step       The step at which the metric was recorded (e.g., training update count).
+     */
+    void record(String metricName, double value, long step);
+
+    /**
+     * Sets a listener to be notified whenever a metric is recorded.
+     * Only one listener can be active at a time. Setting a new listener
+     * will replace the previous one.
+     *
+     * @param listener The {@link MetricListener} to be notified. Can be null to remove the listener.
+     */
+    void setMetricListener(MetricListener listener);
+
+    /**
+     * Retrieves the latest recorded value and step for a specific metric.
+     *
+     * @param metricName The name of the metric.
+     * @return An {@link Optional} containing a {@link Pair} of (step, value) if the metric exists,
+     *         otherwise an empty Optional.
+     */
+    Optional<Pair<Long, Double>> getLatestMetric(String metricName);
+
+    /**
+     * Retrieves the summary statistics for a specific metric.
+     *
+     * @param metricName The name of the metric.
+     * @return An {@link Optional} containing the {@link MetricSummary} if the metric has been recorded,
+     *         otherwise an empty Optional.
+     */
+    Optional<MetricSummary> getSummary(String metricName);
+
+    /**
+     * Retrieves a map of all metric names to their corresponding summary statistics.
+     *
+     * @return A map where keys are metric names and values are their {@link MetricSummary}.
+     *         Returns an empty map if no metrics have been recorded.
+     */
+    Map<String, MetricSummary> getAllSummaries();
+
+    /**
+     * Resets the collector, clearing all recorded metrics, summaries, and removing any listener.
+     * This is useful for starting fresh, e.g., between independent test runs.
+     */
+    void reset();
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg2/stats/MetricListener.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg2/stats/MetricListener.java
@@ -1,0 +1,18 @@
+package jcog.tensor.rl.pg2.stats;
+
+/**
+ * A listener interface for receiving notifications when a metric is recorded.
+ * Implementations can choose to store, log, or process these metrics in real-time.
+ */
+@FunctionalInterface
+public interface MetricListener {
+
+    /**
+     * Called when a metric is recorded.
+     *
+     * @param metricName The name of the metric (e.g., "policy_loss", "reward").
+     * @param step       The step at which the metric was recorded (e.g., training update count, episode number).
+     * @param value      The value of the metric.
+     */
+    void onMetricRecorded(String metricName, long step, double value);
+}

--- a/jcog/rl/src/main/java/jcog/tensor/rl/pg2/stats/MetricSummary.java
+++ b/jcog/rl/src/main/java/jcog/tensor/rl/pg2/stats/MetricSummary.java
@@ -1,0 +1,100 @@
+package jcog.tensor.rl.pg2.stats;
+
+import java.util.Locale;
+
+/**
+ * Holds summary statistics for a specific metric.
+ * This includes the sum of values, count of recordings, minimum value, and maximum value.
+ * The mean can be calculated from the sum and count.
+ */
+public class MetricSummary {
+    private double sum = 0.0;
+    private long count = 0;
+    private double min = Double.MAX_VALUE;
+    private double max = Double.MIN_VALUE;
+
+    /**
+     * Default constructor.
+     */
+    public MetricSummary() {
+    }
+
+    /**
+     * Updates the summary statistics with a new value.
+     *
+     * @param value The new metric value to incorporate into the summary.
+     */
+    public void update(double value) {
+        this.sum += value;
+        this.count++;
+        this.min = Math.min(this.min, value);
+        this.max = Math.max(this.max, value);
+    }
+
+    /**
+     * Gets the sum of all recorded values for this metric.
+     *
+     * @return The sum of values.
+     */
+    public double getSum() {
+        return sum;
+    }
+
+    /**
+     * Gets the total number of times this metric has been recorded.
+     *
+     * @return The count of recordings.
+     */
+    public long getCount() {
+        return count;
+    }
+
+    /**
+     * Gets the minimum value recorded for this metric.
+     * Returns {@link Double#MAX_VALUE} if no values have been recorded.
+     *
+     * @return The minimum value.
+     */
+    public double getMin() {
+        return count == 0 ? Double.MAX_VALUE : min;
+    }
+
+    /**
+     * Gets the maximum value recorded for this metric.
+     * Returns {@link Double#MIN_VALUE} if no values have been recorded.
+     *
+     * @return The maximum value.
+     */
+    public double getMax() {
+        return count == 0 ? Double.MIN_VALUE : max;
+    }
+
+    /**
+     * Calculates the mean (average) of all recorded values for this metric.
+     * Returns {@link Double#NaN} if no values have been recorded (count is zero).
+     *
+     * @return The mean of the values, or NaN if count is zero.
+     */
+    public double getMean() {
+        if (count == 0) {
+            return Double.NaN;
+        }
+        return sum / count;
+    }
+
+    /**
+     * Resets the summary statistics to their initial state.
+     */
+    public void reset() {
+        this.sum = 0.0;
+        this.count = 0;
+        this.min = Double.MAX_VALUE;
+        this.max = Double.MIN_VALUE;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(Locale.ROOT, "MetricSummary{count=%d, mean=%.4f, min=%.4f, max=%.4f, sum=%.4f}",
+                count, getMean(), getMin(), getMax(), sum);
+    }
+}

--- a/jcog/rl/src/test/java/jcog/tensor/rl/pg2/PPOAgentTest.java
+++ b/jcog/rl/src/test/java/jcog/tensor/rl/pg2/PPOAgentTest.java
@@ -1,0 +1,191 @@
+package jcog.tensor.rl.pg2;
+
+import jcog.Util;
+import jcog.math.VecMath;
+import jcog.tensor.Tensor;
+import jcog.tensor.rl.pg.util.Experience2;
+import jcog.tensor.rl.pg2.configs.*;
+import jcog.tensor.rl.pg2.memory.OnPolicyBuffer;
+import jcog.tensor.rl.pg2.stats.DefaultMetricCollector;
+import jcog.tensor.rl.pg2.stats.MetricCollector;
+import jcog.tensor.rl.pg2.stats.MetricSummary;
+import org.junit.jupiter.api.Test;
+import org.eclipse.collections.api.tuple.Pair;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PPOAgentTest {
+
+    // Simple environment for testing: PointNavigation1D
+    static class PointNavigation1D {
+        private double currentState;
+        private final double targetState = 0.0;
+        private final double stepSize = 0.1; // Max action magnitude
+        private final double stateMin = -1.0;
+        private final double stateMax = 1.0;
+        private final int maxStepsPerEpisode = 50;
+        private int currentStepInEpisode;
+        private final Random random = new Random(123); // Seeded for reproducibility
+
+        public PointNavigation1D() {
+            reset();
+        }
+
+        public Tensor reset() {
+            this.currentState = random.nextDouble() * (stateMax - stateMin) + stateMin; // Random start
+            this.currentStepInEpisode = 0;
+            return Tensor.value(this.currentState);
+        }
+
+        // Returns <NextState, Reward, Done>
+        public Triplet<Tensor, Double, Boolean> step(double[] action) {
+            double move = Util.clamp(action[0], -stepSize, stepSize);
+            this.currentState = Util.clamp(this.currentState + move, stateMin, stateMax);
+            this.currentStepInEpisode++;
+
+            double reward = -Math.abs(this.currentState - this.targetState); // Negative distance to target
+
+            boolean done = this.currentStepInEpisode >= this.maxStepsPerEpisode || Math.abs(this.currentState - targetState) < 0.01;
+
+            if (Math.abs(this.currentState - targetState) < 0.01) {
+                reward += 10.0; // Bonus for reaching target
+            }
+
+            // Small penalty for existing
+            // reward -= 0.01;
+
+
+            return new Triplet<>(Tensor.value(this.currentState), reward, done);
+        }
+
+        public int getStateDim() {
+            return 1;
+        }
+
+        public int getActionDim() {
+            return 1;
+        }
+    }
+
+    // Helper record for environment step results
+    record Triplet<S, R, D>(S state, R reward, D done) {}
+
+    @Test
+    void testPPOAgentLearnsOnPointNavigation() {
+        PointNavigation1D env = new PointNavigation1D();
+        int stateDim = env.getStateDim();
+        int actionDim = env.getActionDim();
+
+        PPOAgentConfig config = new PPOAgentConfig(
+                new HyperparamConfig(0.001f, 0.99f, 0.95f, 0.2f, 0.01f, 4, true, 128, 10),
+                new NetworkConfig(List.of(64, 64), true, true, OptimizerConfig.Adam(0.0003f), "tanh"),
+                new NetworkConfig(List.of(64, 64), true, true, OptimizerConfig.Adam(0.0003f), "tanh"),
+                new ActionConfig(0.1f, 1.0f, ActionConfig.ActionNoiseType.GAUSSIAN, 0.1f),
+                new MemoryConfig(MemoryConfig.MemoryType.ON_POLICY_BUFFER, 256, 1) // episodeLength for buffer
+        );
+
+        MetricCollector metricCollector = new DefaultMetricCollector();
+        PPOAgent agent = new PPOAgent(config, stateDim, actionDim, metricCollector);
+        agent.setTrainingMode(true);
+
+        int numEpisodes = 200;
+        int maxUpdates = numEpisodes * env.maxStepsPerEpisode / config.memoryConfig().episodeLength().intValue(); // Approx
+
+        List<Double> episodeRewards = new ArrayList<>();
+        double totalRewardLast50Episodes = 0;
+
+        System.out.println("Starting training on PointNavigation1D...");
+
+        for (int episode = 0; episode < numEpisodes; episode++) {
+            Tensor state = env.reset();
+            double currentEpisodeReward = 0;
+            Tensor oldLogProb = null; // For PPO, this should come from selectActionWithLogProb
+
+            for (int t = 0; t < env.maxStepsPerEpisode; t++) {
+                PPOAgent.ActionWithLogProb actionWithLogProb = agent.selectActionWithLogProb(state, false);
+                double[] action = actionWithLogProb.action();
+                Tensor currentLogProb = actionWithLogProb.logProb();
+
+                Triplet<Tensor, Double, Boolean> stepResult = env.step(action);
+                Tensor nextState = stepResult.state();
+                double reward = stepResult.reward();
+                boolean done = stepResult.done();
+
+                // Store experience: state, action, reward, nextState, done, oldLogProb
+                // Note: Experience2 needs state, action, reward, nextState, done, and optionally oldLogProb.
+                // The oldLogProb for an experience is the logProb of the action *taken in that state*.
+                agent.memory.add(new Experience2(state, action, reward, nextState, done, currentLogProb));
+
+                state = nextState;
+                currentEpisodeReward += reward;
+
+                if (agent.memory.size() >= config.memoryConfig().episodeLength().intValue()) {
+                    agent.update(episode * env.maxStepsPerEpisode + t); // Pass global step, or agent.getUpdateCount()
+                    agent.memory.clear(); // For on-policy
+                }
+
+                if (done) break;
+            }
+            episodeRewards.add(currentEpisodeReward);
+            if (episode >= numEpisodes - 50) {
+                totalRewardLast50Episodes += currentEpisodeReward;
+            }
+
+            if ((episode + 1) % 20 == 0) {
+                System.out.printf("Episode %d, Avg Reward (last 20): %.2f, Total Updates: %d%n",
+                        episode + 1,
+                        episodeRewards.subList(Math.max(0, episodeRewards.size()-20), episodeRewards.size())
+                                .stream().mapToDouble(Double::doubleValue).average().orElse(Double.NaN),
+                        agent.getUpdateCount());
+
+                metricCollector.getSummary("policy_loss").ifPresent(s -> System.out.printf("  Policy Loss: %.4f%n", s.getMean()));
+                metricCollector.getSummary("value_loss").ifPresent(s -> System.out.printf("  Value Loss: %.4f%n", s.getMean()));
+                metricCollector.getSummary("entropy").ifPresent(s -> System.out.printf("  Entropy: %.4f%n", s.getMean()));
+
+            }
+        }
+
+        System.out.println("Training finished.");
+        System.out.println("Total updates: " + agent.getUpdateCount());
+
+        // Assertions
+        assertTrue(agent.getUpdateCount() > 0, "Agent should have performed updates.");
+
+        Optional<MetricSummary> policyLossSummaryOpt = metricCollector.getSummary("policy_loss");
+        assertTrue(policyLossSummaryOpt.isPresent(), "Policy loss should have been recorded.");
+        System.out.printf("Policy Loss Summary: %s%n", policyLossSummaryOpt.get());
+
+        Optional<MetricSummary> valueLossSummaryOpt = metricCollector.getSummary("value_loss");
+        assertTrue(valueLossSummaryOpt.isPresent(), "Value loss should have been recorded.");
+        System.out.printf("Value Loss Summary: %s%n", valueLossSummaryOpt.get());
+
+        // Check that average reward in the last 50 episodes is significantly better than the first 50
+        // This is a basic check for learning. More sophisticated checks might look at loss curves.
+        double avgRewardFirst50 = episodeRewards.subList(0, Math.min(50, episodeRewards.size()))
+                                    .stream().mapToDouble(r -> r).average().orElse(Double.NEGATIVE_INFINITY);
+        double avgRewardLast50 = totalRewardLast50Episodes / Math.min(50, episodeRewards.size() - (numEpisodes - 50) );
+
+        System.out.printf("Avg Reward First 50 Episodes: %.2f%n", avgRewardFirst50);
+        System.out.printf("Avg Reward Last 50 Episodes: %.2f%n", avgRewardLast50);
+
+        // A simple environment like PointNavigation should show clear improvement.
+        // The exact values depend heavily on reward structure and hyperparameters.
+        // We expect last 50 to be substantially higher than first 50 if learning occurred.
+        // Initial rewards are around -25 to -50 (avg -0.5 to -1 per step for 50 steps).
+        // Optimal reward is close to 10 (reaching target quickly).
+        assertTrue(avgRewardLast50 > avgRewardFirst50 + 5, // Expect at least some improvement. This threshold might need tuning.
+                "Average reward in later episodes should be significantly higher than in early episodes." +
+                " Last50: " + avgRewardLast50 + ", First50: " + avgRewardFirst50);
+
+        // Check if loss values are sensible (not NaN or Infinity)
+        // Further checks could involve storing initial vs final loss values and asserting decrease.
+        // For now, checking presence and getting the mean is a start.
+        assertFalse(Double.isNaN(policyLossSummaryOpt.get().getMean()), "Policy loss mean should not be NaN.");
+        assertFalse(Double.isNaN(valueLossSummaryOpt.get().getMean()), "Value loss mean should not be NaN.");
+    }
+}


### PR DESCRIPTION
Adds a generic metric collection system to `jcog.tensor.rl.pg2.stats` including `MetricCollector`, `MetricListener`, and `MetricSummary`. `DefaultMetricCollector` provides an implementation that stores latest values, summaries, and supports an optional listener for all data points.

Integrates metric collection into `BasePolicyGradientAgent` and `PPOAgent`. `PPOAgent` now records key metrics during training:
- Policy Loss
- Value Loss
- Entropy
- GAE Advantages (raw and normalized means)
- Policy Sigma (mean and std)

Adds a unit test `PPOAgentTest` with a simple `PointNavigation1D` environment to demonstrate `PPOAgent` learning and the usage of the metric system to verify convergence. The test asserts that rewards improve and that collected metrics are valid.

This enhancement allows for better monitoring, debugging, and automated testing of RL agent performance and learning stability within the pg2 framework.