### PR TITLE
Launcher: support Game(String) constructors

### DIFF
--- a/narchy/lab/src/main/java/nars/Launcher.java
+++ b/narchy/lab/src/main/java/nars/Launcher.java
@@ -96,6 +96,10 @@ public class Launcher {
                     try {
                         g = env.getConstructor(NAR.class).newInstance(p.nar);
                     } catch (Exception e3) {
+                        try {
+                            g = env.getConstructor(String.class).newInstance($.uuid().toString());
+                        } catch (Exception e4) {
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Experiments that declare only a `(String id)` constructor (e.g. `nars.experiment.Pacman`) cannot be started from `nars.Launcher`: the existing `()`/`(Term)`/`(NAR)` construction attempts all fail and clicking the experiment throws `WTF: ... constructor unsupported`.

This adds a final fallback that tries `(String)` with a generated uuid id, matching the pattern of the existing fallbacks.

Tested by building `narchy/lab` (JDK 25) and launching `n.jar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)